### PR TITLE
Implementation of pipes

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -1,6 +1,7 @@
 package nash
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -392,9 +393,13 @@ func (cmd *Command) setupRedirects() error {
 }
 
 func (cmd *Command) Wait() error {
+	fmt.Printf("a\n")
 	<-cmd.stdinDone
+	fmt.Printf("b\n")
 	<-cmd.stdoutDone
+	fmt.Printf("c\n")
 	<-cmd.stderrDone
+	fmt.Printf("d\n")
 
 	return cmd.Cmd.Wait()
 }

--- a/cmd.go
+++ b/cmd.go
@@ -1,7 +1,6 @@
 package nash
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -393,13 +392,9 @@ func (cmd *Command) setupRedirects() error {
 }
 
 func (cmd *Command) Wait() error {
-	fmt.Printf("a\n")
 	<-cmd.stdinDone
-	fmt.Printf("b\n")
 	<-cmd.stdoutDone
-	fmt.Printf("c\n")
 	<-cmd.stderrDone
-	fmt.Printf("d\n")
 
 	return cmd.Cmd.Wait()
 }

--- a/itemtype_string.go
+++ b/itemtype_string.go
@@ -4,9 +4,9 @@ package nash
 
 import "fmt"
 
-const _itemType_name = "itemErroritemEOFitemBuiltinitemImportitemCommentitemSetEnvitemShowEnvitemVarNameitemAssignitemAssignCmditemConcatitemVariableitemListOpenitemListCloseitemListElemitemCommanditemBindFnitemArgitemLeftBlockitemRightBlockitemLeftParenitemRightParenitemStringitemRedirRightitemRedirRBracketitemRedirLBracketitemRedirFileitemRedirNetAddritemRedirMapEqualitemRedirMapLSideitemRedirMapRSideitemIfitemElseitemComparisonitemRforkitemRforkFlagsitemCditemFnDeclitemFnInv"
+const _itemType_name = "itemErroritemEOFitemBuiltinitemImportitemCommentitemSetEnvitemShowEnvitemVarNameitemAssignitemAssignCmditemConcatitemVariableitemListOpenitemListCloseitemListElemitemCommanditemPipeitemBindFnitemArgitemLeftBlockitemRightBlockitemLeftParenitemRightParenitemStringitemRedirRightitemRedirRBracketitemRedirLBracketitemRedirFileitemRedirNetAddritemRedirMapEqualitemRedirMapLSideitemRedirMapRSideitemIfitemElseitemComparisonitemRforkitemRforkFlagsitemCditemFnDeclitemFnInv"
 
-var _itemType_index = [...]uint16{0, 9, 16, 27, 37, 48, 58, 69, 80, 90, 103, 113, 125, 137, 150, 162, 173, 183, 190, 203, 217, 230, 244, 254, 268, 285, 302, 315, 331, 348, 365, 382, 388, 396, 410, 419, 433, 439, 449, 458}
+var _itemType_index = [...]uint16{0, 9, 16, 27, 37, 48, 58, 69, 80, 90, 103, 113, 125, 137, 150, 162, 173, 181, 191, 198, 211, 225, 238, 252, 262, 276, 293, 310, 323, 339, 356, 373, 390, 396, 404, 418, 427, 441, 447, 457, 466}
 
 func (i itemType) String() string {
 	i -= 2

--- a/lex.go
+++ b/lex.go
@@ -53,6 +53,7 @@ const (
 	itemListClose
 	itemListElem
 	itemCommand // alphanumeric identifier that's not a keyword
+	itemPipe    // ls | wc -l
 	itemBindFn  // "bindfn <fn> <cmd>
 	itemArg
 	itemLeftBlock     // {
@@ -1010,6 +1011,9 @@ func lexInsideCommand(l *lexer) stateFn {
 	case r == '>':
 		l.emit(itemRedirRight)
 		return lexInsideRedirect
+	case r == '|':
+		l.emit(itemPipe)
+		return lexStart
 	case r == '$':
 		l.backup()
 		return lexInsideCommonVariable(l, lexInsideCommand)

--- a/lex_test.go
+++ b/lex_test.go
@@ -543,6 +543,68 @@ func TestLexerSimpleCommand(t *testing.T) {
 
 }
 
+func TestLexerPipe(t *testing.T) {
+	expected := []item{
+		item{
+			typ: itemCommand,
+			val: "ls",
+		},
+		item{
+			typ: itemPipe,
+			val: "|",
+		},
+		item{
+			typ: itemCommand,
+			val: "wc",
+		},
+		item{
+			typ: itemArg,
+			val: "-l",
+		},
+		item{
+			typ: itemEOF,
+		},
+	}
+
+	testTable("testPipe", `ls | wc -l`, expected, t)
+
+	expected = []item{
+		item{
+			typ: itemCommand,
+			val: "ls",
+		},
+		item{
+			typ: itemArg,
+			val: "-l",
+		},
+		item{
+			typ: itemPipe,
+			val: "|",
+		},
+		item{
+			typ: itemCommand,
+			val: "wc",
+		},
+		item{
+			typ: itemPipe,
+			val: "|",
+		},
+		item{
+			typ: itemCommand,
+			val: "awk",
+		},
+		item{
+			typ: itemString,
+			val: "{print $1}",
+		},
+		item{
+			typ: itemEOF,
+		},
+	}
+
+	testTable("testPipe", `ls -l | wc | awk "{print $1}"`, expected, t)
+}
+
 func TestLexerUnquoteArg(t *testing.T) {
 	expected := []item{
 		item{

--- a/nash.go
+++ b/nash.go
@@ -426,6 +426,10 @@ func (sh *Shell) executePipe(pipe *PipeNode) error {
 	for i, cmd := range cmds[:last] {
 		nodeCmd := nodeCommands[i]
 
+		cmd.SetFDMap(0, sh.stdin)
+		//		cmd.SetFDMap(1, sh.stdout)
+		cmd.SetFDMap(2, sh.stderr)
+
 		err = cmd.SetRedirects(nodeCmd.redirs)
 
 		if err != nil {
@@ -450,6 +454,7 @@ func (sh *Shell) executePipe(pipe *PipeNode) error {
 	}
 
 	if sh.stdin != os.Stdin {
+		cmds[last].Stdin = nil
 		stdin, err := cmds[last].StdinPipe()
 
 		if err != nil {

--- a/nash_test.go
+++ b/nash_test.go
@@ -796,4 +796,22 @@ func TestExecutePipe(t *testing.T) {
 		t.Errorf("Expected '1' but found '%s'", strOut)
 		return
 	}
+
+	out.Reset()
+
+	err = sh.ExecuteString("test pipe 3", `echo hello | wc -l | grep 1`)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	strOut = strings.TrimSpace(string(out.Bytes()))
+
+	if strOut != "1" {
+		t.Errorf("Expected '1' but found '%s'", strOut)
+		return
+	}
+
+	out.Reset()
 }

--- a/nash_test.go
+++ b/nash_test.go
@@ -769,3 +769,31 @@ func TestExecuteBindFn(t *testing.T) {
 		return
 	}
 }
+
+func TestExecutePipe(t *testing.T) {
+	var out bytes.Buffer
+
+	sh, err := NewShell(false)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	sh.SetNashdPath(nashdPath)
+	sh.SetStdout(&out)
+
+	err = sh.ExecuteString("test pipe", `echo hello | wc -l`)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	strOut := strings.TrimSpace(string(out.Bytes()))
+
+	if strOut != "1" {
+		t.Errorf("Expected '1' but found '%s'", strOut)
+		return
+	}
+}

--- a/node.go
+++ b/node.go
@@ -65,7 +65,7 @@ type (
 		NodeType
 		Pos
 		name string
-		cmd  *CommandNode
+		cmd  Node
 	}
 
 	// CommandNode is a node for commands
@@ -365,7 +365,7 @@ func (n *CmdAssignmentNode) Name() string {
 	return n.name
 }
 
-func (n *CmdAssignmentNode) Command() *CommandNode {
+func (n *CmdAssignmentNode) Command() Node {
 	return n.cmd
 }
 
@@ -373,7 +373,7 @@ func (n *CmdAssignmentNode) SetName(name string) {
 	n.name = name
 }
 
-func (n *CmdAssignmentNode) SetCommand(c *CommandNode) {
+func (n *CmdAssignmentNode) SetCommand(c Node) {
 	n.cmd = c
 }
 

--- a/node.go
+++ b/node.go
@@ -77,6 +77,12 @@ type (
 		redirs []*RedirectNode
 	}
 
+	PipeNode struct {
+		NodeType
+		Pos
+		cmds []*CommandNode
+	}
+
 	// Arg is a command argument
 	Arg struct {
 		NodeType
@@ -178,6 +184,9 @@ const (
 
 	// NodeCommand are command statements
 	NodeCommand
+
+	// NodePipe is the node type for pipes
+	NodePipe
 
 	// NodeArg are nodes for command arguments
 	NodeArg
@@ -417,6 +426,36 @@ func (n *CommandNode) String() string {
 	content = append(content, redirs...)
 
 	return strings.Join(content, " ")
+}
+
+func NewPipeNode(pos Pos) *PipeNode {
+	return &PipeNode{
+		NodeType: NodePipe,
+		Pos:      pos,
+		cmds:     make([]*CommandNode, 0, 16),
+	}
+}
+
+func (n *PipeNode) AddCmd(c *CommandNode) {
+	n.cmds = append(n.cmds, c)
+}
+
+func (n *PipeNode) Commands() []*CommandNode {
+	return n.cmds
+}
+
+func (n *PipeNode) String() string {
+	ret := ""
+
+	for i := 0; i < len(n.cmds); i++ {
+		ret += n.cmds[i].String()
+
+		if i < (len(n.cmds) - 1) {
+			ret += " | "
+		}
+	}
+
+	return ret
 }
 
 // NewRedirectNode creates a new redirection node for commands

--- a/nodetype_string.go
+++ b/nodetype_string.go
@@ -4,9 +4,9 @@ package nash
 
 import "fmt"
 
-const _NodeType_name = "NodeSetAssignmentNodeShowEnvNodeAssignmentNodeCmdAssignmentNodeImportNodeCommandNodeArgNodeStringNodeRforkNodeCdNodeRforkFlagsNodeIfNodeCommentNodeFnDeclNodeFnInvNodeBindFn"
+const _NodeType_name = "NodeSetAssignmentNodeShowEnvNodeAssignmentNodeCmdAssignmentNodeImportNodeCommandNodePipeNodeArgNodeStringNodeRforkNodeCdNodeRforkFlagsNodeIfNodeCommentNodeFnDeclNodeFnInvNodeBindFn"
 
-var _NodeType_index = [...]uint8{0, 17, 28, 42, 59, 69, 80, 87, 97, 106, 112, 126, 132, 143, 153, 162, 172}
+var _NodeType_index = [...]uint8{0, 17, 28, 42, 59, 69, 80, 88, 95, 105, 114, 120, 134, 140, 151, 161, 170, 180}
 
 func (i NodeType) String() string {
 	i -= 1

--- a/parse.go
+++ b/parse.go
@@ -462,7 +462,7 @@ func (p *Parser) parseAssignCmdOut(name item) (Node, error) {
 		return nil, err
 	}
 
-	n.SetCommand(cmd.(*CommandNode))
+	n.SetCommand(cmd)
 
 	return n, nil
 }

--- a/parse.go
+++ b/parse.go
@@ -14,6 +14,8 @@ type (
 		l          *lexer
 		tok        *item // token saved for lookahead
 		openblocks int
+
+		insidePipe bool
 	}
 )
 
@@ -79,6 +81,26 @@ func (p *Parser) peek() item {
 	return i
 }
 
+func (p *Parser) parsePipe(first *CommandNode) (Node, error) {
+	it := p.next()
+
+	n := NewPipeNode(it.pos)
+
+	n.AddCmd(first)
+
+	for it = p.peek(); it.typ == itemCommand; it = p.peek() {
+		cmd, err := p.parseCommand()
+
+		if err != nil {
+			return nil, err
+		}
+
+		n.AddCmd(cmd.(*CommandNode))
+	}
+
+	return n, nil
+}
+
 func (p *Parser) parseCommand() (Node, error) {
 	it := p.next()
 
@@ -112,6 +134,14 @@ func (p *Parser) parseCommand() (Node, error) {
 			}
 
 			n.AddRedirect(redir)
+		case itemPipe:
+			if p.insidePipe {
+				p.next()
+				return n, nil
+			}
+
+			p.insidePipe = true
+			return p.parsePipe(n)
 		case itemEOF:
 			return n, nil
 		case itemError:

--- a/parse_test.go
+++ b/parse_test.go
@@ -83,6 +83,31 @@ func TestParseReverseGetSame(t *testing.T) {
 	}
 }
 
+func TestParsePipe(t *testing.T) {
+	expected := NewTree("parser pipe")
+	ln := NewListNode()
+	first := NewCommandNode(0, "echo")
+	hello := NewArg(6, ArgQuoted)
+	hello.SetString("hello world")
+	first.AddArg(hello)
+
+	second := NewCommandNode(21, "awk")
+	secondArg := NewArg(26, ArgQuoted)
+	secondArg.SetString("{print $1}")
+
+	second.AddArg(secondArg)
+
+	pipe := NewPipeNode(19)
+	pipe.AddCmd(first)
+	pipe.AddCmd(second)
+
+	ln.Push(pipe)
+
+	expected.Root = ln
+
+	parserTestTable("parser pipe", `echo "hello world" | awk "{print $1}"`, expected, t)
+}
+
 func TestBasicSetAssignment(t *testing.T) {
 	expected := NewTree("simple set assignment")
 	ln := NewListNode()

--- a/parse_util_test.go
+++ b/parse_util_test.go
@@ -382,7 +382,21 @@ func compareCmdAssignmentNode(expected, value *CmdAssignmentNode) (bool, error) 
 		return false, fmt.Errorf(" CompareCmdAssignmentnode (%v, %v) -> '%s' != '%s'", expected, value, ename, vname)
 	}
 
-	return compareCommandNode(expected.Command(), value.Command())
+	ecmd := expected.Command()
+	vcmd := value.Command()
+
+	if ecmd.Type() != vcmd.Type() {
+		return false, fmt.Errorf("Node type differs: %s != %s", ecmd.Type(), vcmd.Type())
+	}
+
+	switch ecmd.Type() {
+	case NodeCommand:
+		return compareCommandNode(ecmd.(*CommandNode), vcmd.(*CommandNode))
+	case NodePipe:
+		return comparePipeNode(ecmd.(*PipeNode), vcmd.(*PipeNode))
+	}
+
+	return false, fmt.Errorf("Unexpected type %s", ecmd.Type())
 }
 
 func compareIfNode(expected, value *IfNode) (bool, error) {

--- a/parse_util_test.go
+++ b/parse_util_test.go
@@ -136,6 +136,36 @@ func compareCdNode(expected, value *CdNode) (bool, error) {
 	return true, nil
 }
 
+func comparePipeNode(expected, value *PipeNode) (bool, error) {
+	if ok, err := compareDefault(expected, value); !ok {
+		return ok, err
+	}
+
+	ecmds := expected.Commands()
+	vcmds := value.Commands()
+
+	if len(ecmds) != len(vcmds) {
+		return false, fmt.Errorf(" comparePipeNode - length differs: %d != %d", len(ecmds), len(vcmds))
+	}
+
+	for i := 0; i < len(ecmds); i++ {
+		ecmd := ecmds[i]
+		vcmd := vcmds[i]
+
+		ok, err := compareCommandNode(ecmd, vcmd)
+
+		if !ok {
+			return ok, err
+		}
+	}
+
+	if expected.String() != value.String() {
+		return false, fmt.Errorf("String differs: '%s' != '%s'", expected.String(), value.String())
+	}
+
+	return true, nil
+}
+
 func compareCommandNode(expected *CommandNode, value *CommandNode) (bool, error) {
 	if expected == nil && value == nil {
 		return true, nil
@@ -452,6 +482,10 @@ func compareNodes(expected Node, value Node) (bool, error) {
 		ec := expected.(*CommandNode)
 		vc := value.(*CommandNode)
 		valid, err = compareCommandNode(ec, vc)
+	case *PipeNode:
+		ec := expected.(*PipeNode)
+		vc := value.(*PipeNode)
+		valid, err = comparePipeNode(ec, vc)
 	case *CommentNode:
 		ec := expected.(*CommentNode)
 		vc := value.(*CommentNode)


### PR DESCRIPTION
Usage is like Posix and pipe execution can be assigned to variables much like commands, using the '<=' operator.

```sh
λ> cat /etc/passwd | grep root
# assignment of a pipe
λ> ipaddr <= ip a | grep inet | grep global | awk "{print $2}" | cut -d / -f1
λ> echo $ipaddr
10.137.2.14
```
