### PR TITLE
[WIP] Function return statement

### DIFF
--- a/cmd/nash/cli.go
+++ b/cmd/nash/cli.go
@@ -138,7 +138,7 @@ func cli(sh *nash.Shell) error {
 
 		content.Reset()
 
-		err = sh.ExecuteTree(tr)
+		_, err = sh.ExecuteTree(tr)
 
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err.Error())

--- a/itemtype_string.go
+++ b/itemtype_string.go
@@ -4,9 +4,9 @@ package nash
 
 import "fmt"
 
-const _itemType_name = "itemErroritemEOFitemBuiltinitemImportitemCommentitemSetEnvitemShowEnvitemVarNameitemAssignitemAssignCmditemConcatitemVariableitemListOpenitemListCloseitemListElemitemCommanditemPipeitemBindFnitemDumpitemArgitemLeftBlockitemRightBlockitemLeftParenitemRightParenitemStringitemRedirRightitemRedirRBracketitemRedirLBracketitemRedirFileitemRedirNetAddritemRedirMapEqualitemRedirMapLSideitemRedirMapRSideitemIfitemElseitemComparisonitemRforkitemRforkFlagsitemCditemFnDeclitemFnInv"
+const _itemType_name = "itemErroritemEOFitemBuiltinitemImportitemCommentitemSetEnvitemShowEnvitemVarNameitemAssignitemAssignCmditemConcatitemVariableitemListOpenitemListCloseitemListElemitemCommanditemPipeitemBindFnitemDumpitemReturnitemArgitemLeftBlockitemRightBlockitemLeftParenitemRightParenitemStringitemRedirRightitemRedirRBracketitemRedirLBracketitemRedirFileitemRedirNetAddritemRedirMapEqualitemRedirMapLSideitemRedirMapRSideitemIfitemElseitemComparisonitemRforkitemRforkFlagsitemCditemFnDeclitemFnInv"
 
-var _itemType_index = [...]uint16{0, 9, 16, 27, 37, 48, 58, 69, 80, 90, 103, 113, 125, 137, 150, 162, 173, 181, 191, 199, 206, 219, 233, 246, 260, 270, 284, 301, 318, 331, 347, 364, 381, 398, 404, 412, 426, 435, 449, 455, 465, 474}
+var _itemType_index = [...]uint16{0, 9, 16, 27, 37, 48, 58, 69, 80, 90, 103, 113, 125, 137, 150, 162, 173, 181, 191, 199, 209, 216, 229, 243, 256, 270, 280, 294, 311, 328, 341, 357, 374, 391, 408, 414, 422, 436, 445, 459, 465, 475, 484}
 
 func (i itemType) String() string {
 	i -= 2

--- a/lex_test.go
+++ b/lex_test.go
@@ -2514,7 +2514,7 @@ func TestLexerDump(t *testing.T) {
 	testTable("test dump", `dump out`, expected, t)
 }
 
-/*func TestLexerReturn(t *testing.T) {
+func TestLexerReturn(t *testing.T) {
 	expected := []item{
 		item{
 			typ: itemReturn,
@@ -2525,5 +2525,199 @@ func TestLexerDump(t *testing.T) {
 		},
 	}
 
-	testTableFail("test return", "return", expected, t)
-}*/
+	testTable("test return", "return", expected, t)
+
+	expected = []item{
+		item{
+			typ: itemFnDecl,
+			val: "fn",
+		},
+		item{
+			typ: itemVarName,
+			val: "test",
+		},
+		item{
+			typ: itemLeftParen,
+			val: "(",
+		},
+		item{
+			typ: itemRightParen,
+			val: ")",
+		},
+		item{
+			typ: itemLeftBlock,
+			val: "{",
+		},
+		item{
+			typ: itemReturn,
+			val: "return",
+		},
+		item{
+			typ: itemRightBlock,
+			val: "}",
+		},
+		item{
+			typ: itemEOF,
+		},
+	}
+
+	testTable("test return", "fn test() { return }", expected, t)
+	testTable("test return", `fn test() {
+ return
+}`, expected, t)
+	testTable("test return", `fn test() {
+	return
+}`, expected, t)
+
+	expected = []item{
+		item{
+			typ: itemFnDecl,
+			val: "fn",
+		},
+		item{
+			typ: itemVarName,
+			val: "test",
+		},
+		item{
+			typ: itemLeftParen,
+			val: "(",
+		},
+		item{
+			typ: itemRightParen,
+			val: ")",
+		},
+		item{
+			typ: itemLeftBlock,
+			val: "{",
+		},
+		item{
+			typ: itemReturn,
+			val: "return",
+		},
+		item{
+			typ: itemString,
+			val: "some value",
+		},
+		item{
+			typ: itemRightBlock,
+			val: "}",
+		},
+		item{
+			typ: itemEOF,
+		},
+	}
+
+	testTable("test return", `fn test() { return "some value"}`, expected, t)
+	testTable("test return", `fn test() {
+	return "some value"
+}`, expected, t)
+
+	expected = []item{
+		item{
+			typ: itemFnDecl,
+			val: "fn",
+		},
+		item{
+			typ: itemVarName,
+			val: "test",
+		},
+		item{
+			typ: itemLeftParen,
+			val: "(",
+		},
+		item{
+			typ: itemRightParen,
+			val: ")",
+		},
+		item{
+			typ: itemLeftBlock,
+			val: "{",
+		},
+		item{
+			typ: itemVarName,
+			val: "value",
+		},
+		item{
+			typ: itemAssign,
+			val: "=",
+		},
+		item{
+			typ: itemString,
+			val: "some value",
+		},
+		item{
+			typ: itemReturn,
+			val: "return",
+		},
+		item{
+			typ: itemVariable,
+			val: "$value",
+		},
+		item{
+			typ: itemRightBlock,
+			val: "}",
+		},
+		item{
+			typ: itemEOF,
+		},
+	}
+
+	testTable("test return", `fn test() {
+	value = "some value"
+	return $value
+}`, expected, t)
+
+	expected = []item{
+		item{
+			typ: itemFnDecl,
+			val: "fn",
+		},
+		item{
+			typ: itemVarName,
+			val: "test",
+		},
+		item{
+			typ: itemLeftParen,
+			val: "(",
+		},
+		item{
+			typ: itemRightParen,
+			val: ")",
+		},
+		item{
+			typ: itemLeftBlock,
+			val: "{",
+		},
+		item{
+			typ: itemReturn,
+			val: "return",
+		},
+		item{
+			typ: itemListOpen,
+			val: "(",
+		},
+		item{
+			typ: itemString,
+			val: "test",
+		},
+		item{
+			typ: itemString,
+			val: "test2",
+		},
+		item{
+			typ: itemListClose,
+			val: ")",
+		},
+		item{
+			typ: itemRightBlock,
+			val: "}",
+		},
+		item{
+			typ: itemEOF,
+		},
+	}
+
+	testTable("test return", `fn test() {
+	return ("test" "test2")
+}`, expected, t)
+}

--- a/lex_test.go
+++ b/lex_test.go
@@ -2720,4 +2720,46 @@ func TestLexerReturn(t *testing.T) {
 	testTable("test return", `fn test() {
 	return ("test" "test2")
 }`, expected, t)
+
+	expected = []item{
+		item{
+			typ: itemFnDecl,
+			val: "fn",
+		},
+		item{
+			typ: itemVarName,
+			val: "test",
+		},
+		item{
+			typ: itemLeftParen,
+			val: "(",
+		},
+		item{
+			typ: itemRightParen,
+			val: ")",
+		},
+		item{
+			typ: itemLeftBlock,
+			val: "{",
+		},
+		item{
+			typ: itemReturn,
+			val: "return",
+		},
+		item{
+			typ: itemVariable,
+			val: "$PWD",
+		},
+		item{
+			typ: itemRightBlock,
+			val: "}",
+		},
+		item{
+			typ: itemEOF,
+		},
+	}
+
+	testTable("test return", `fn test() {
+	return $PWD
+}`, expected, t)
 }

--- a/nash.go
+++ b/nash.go
@@ -316,8 +316,6 @@ func (sh *Shell) setupSignals() {
 			sh.Lock()
 			sh.interrupted = !sh.interrupted
 			sh.Unlock()
-
-			//			fmt.Println("^C")
 		}
 	}()
 }
@@ -473,8 +471,6 @@ func (sh *Shell) executeReturn(n *ReturnNode) ([]string, error) {
 	returnValue := make([]string, 0, 64)
 
 	for _, arg := range n.arg {
-		fmt.Printf("return value: %v\n", arg)
-
 		if arg.IsVariable() {
 			values, err := sh.evalVariable(arg.Value())
 
@@ -801,6 +797,8 @@ func (sh *Shell) executeCmdAssignment(v *CmdAssignmentNode) error {
 
 	sh.SetStdout(&varOut)
 
+	defer sh.SetStdout(bkStdout)
+
 	assign := v.Command()
 
 	switch assign.Type() {
@@ -810,8 +808,6 @@ func (sh *Shell) executeCmdAssignment(v *CmdAssignmentNode) error {
 		err = sh.executePipe(assign.(*PipeNode))
 	case NodeFnInv:
 		fnValues, err := sh.executeFnInv(assign.(*FnInvNode))
-
-		fmt.Printf("FNVALUES: %v, err = %v\n", fnValues, err)
 
 		if err != nil {
 			return err
@@ -823,8 +819,6 @@ func (sh *Shell) executeCmdAssignment(v *CmdAssignmentNode) error {
 		err = newError("Unexpected node in assignment: %s", assign.String())
 	}
 
-	sh.SetStdout(bkStdout)
-
 	if err != nil {
 		return err
 	}
@@ -835,7 +829,6 @@ func (sh *Shell) executeCmdAssignment(v *CmdAssignmentNode) error {
 	return nil
 }
 
-// Note(i4k): shit code
 func (sh *Shell) executeAssignment(v *AssignmentNode) error {
 	var err error
 

--- a/nash_test.go
+++ b/nash_test.go
@@ -902,3 +902,29 @@ func TestExecuteNetRedirection(t *testing.T) {
 	}
 
 }
+
+func TestExecuteReturn(t *testing.T) {
+	sh, err := NewShell(false)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	sh.SetNashdPath(nashdPath)
+
+	err = sh.ExecuteString("test return fail", "return")
+
+	if err == nil {
+		t.Errorf("Must fail. Return is only valid inside function")
+		return
+	}
+
+	err = sh.ExecuteString("test return", `fn test() { return }
+test()`)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}

--- a/node.go
+++ b/node.go
@@ -156,6 +156,12 @@ type (
 		args []*Arg
 	}
 
+	ReturnNode struct {
+		NodeType
+		Pos
+		arg []*Arg
+	}
+
 	BindFnNode struct {
 		NodeType
 		Pos
@@ -216,6 +222,9 @@ const (
 
 	// NodeFn are function nodes
 	NodeFnDecl
+
+	// NodeReturn is the node for "return" statements
+	NodeReturn
 
 	// NodeFnInv is a node for function invocation
 	NodeFnInv
@@ -939,4 +948,29 @@ func (n *DumpNode) String() string {
 	}
 
 	return "dump"
+}
+
+func NewReturnNode(pos Pos) *ReturnNode {
+	return &ReturnNode{
+		Pos:      pos,
+		NodeType: NodeReturn,
+	}
+}
+
+func (n *ReturnNode) SetReturn(a []*Arg) {
+	n.arg = a
+}
+
+func (n *ReturnNode) Return() []*Arg { return n.arg }
+
+func (n *ReturnNode) String() string {
+	if n.arg != nil {
+		if len(n.arg) > 1 || len(n.arg) == 0 {
+			return "not implemented"
+		}
+
+		return "return " + n.arg[0].String()
+	}
+
+	return "return"
 }

--- a/node.go
+++ b/node.go
@@ -966,7 +966,13 @@ func (n *ReturnNode) Return() []*Arg { return n.arg }
 func (n *ReturnNode) String() string {
 	if n.arg != nil {
 		if len(n.arg) > 1 || len(n.arg) == 0 {
-			return "not implemented"
+			values := make([]string, 0, len(n.arg))
+
+			for _, a := range n.arg {
+				values = append(values, a.String())
+			}
+
+			return "return (" + strings.Join(values, " ") + ")"
 		}
 
 		return "return " + n.arg[0].String()

--- a/nodetype_string.go
+++ b/nodetype_string.go
@@ -4,9 +4,9 @@ package nash
 
 import "fmt"
 
-const _NodeType_name = "NodeSetAssignmentNodeShowEnvNodeAssignmentNodeCmdAssignmentNodeImportNodeCommandNodePipeNodeArgNodeStringNodeRforkNodeCdNodeRforkFlagsNodeIfNodeCommentNodeFnDeclNodeFnInvNodeBindFnNodeDump"
+const _NodeType_name = "NodeSetAssignmentNodeShowEnvNodeAssignmentNodeCmdAssignmentNodeImportNodeCommandNodePipeNodeArgNodeStringNodeRforkNodeCdNodeRforkFlagsNodeIfNodeCommentNodeFnDeclNodeReturnNodeFnInvNodeBindFnNodeDump"
 
-var _NodeType_index = [...]uint8{0, 17, 28, 42, 59, 69, 80, 88, 95, 105, 114, 120, 134, 140, 151, 161, 170, 180, 188}
+var _NodeType_index = [...]uint8{0, 17, 28, 42, 59, 69, 80, 88, 95, 105, 114, 120, 134, 140, 151, 161, 171, 180, 190, 198}
 
 func (i NodeType) String() string {
 	i -= 1

--- a/parse.go
+++ b/parse.go
@@ -816,8 +816,6 @@ func (p *Parser) parseReturn() (Node, error) {
 			return nil, newUnfinishedListError()
 		}
 
-		fmt.Printf("PARSED VALUES = %v\n", values)
-
 		ret.SetReturn(values)
 		return ret, nil
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -930,6 +930,17 @@ func TestParseDump(t *testing.T) {
 	parserTestTable("dump", `dump ./init`, expected, t, true)
 }
 
+func TestParseReturn(t *testing.T) {
+	expected := NewTree("return")
+	ln := NewListNode()
+
+	ret := NewReturnNode(0)
+	ln.Push(ret)
+	expected.Root = ln
+
+	parserTestTable("return", `return`, expected, t, true)
+}
+
 func TestParseIfInvalid(t *testing.T) {
 	parser := NewParser("if invalid", `if a == b { pwd }`)
 	_, err := parser.Parse()

--- a/parse_test.go
+++ b/parse_test.go
@@ -939,6 +939,57 @@ func TestParseReturn(t *testing.T) {
 	expected.Root = ln
 
 	parserTestTable("return", `return`, expected, t, true)
+
+	expected = NewTree("return list")
+	ln = NewListNode()
+
+	ret = NewReturnNode(0)
+	listvalues := make([]*Arg, 2)
+	arg1 := NewArg(9, ArgQuoted)
+	arg1.SetString("val1")
+	arg2 := NewArg(16, ArgQuoted)
+	arg2.SetString("val2")
+	listvalues[0] = arg1
+	listvalues[1] = arg2
+
+	ret.SetReturn(listvalues)
+
+	ln.Push(ret)
+	expected.Root = ln
+
+	parserTestTable("return", `return ("val1" "val2")`, expected, t, true)
+
+	expected = NewTree("return variable")
+	ln = NewListNode()
+
+	ret = NewReturnNode(0)
+	listvalues = make([]*Arg, 1)
+	arg1 = NewArg(7, ArgVariable)
+	arg1.SetString("$var")
+	listvalues[0] = arg1
+
+	ret.SetReturn(listvalues)
+
+	ln.Push(ret)
+	expected.Root = ln
+
+	parserTestTable("return", `return $var`, expected, t, true)
+
+	expected = NewTree("return string")
+	ln = NewListNode()
+
+	ret = NewReturnNode(0)
+	listvalues = make([]*Arg, 1)
+	arg1 = NewArg(8, ArgQuoted)
+	arg1.SetString("value")
+	listvalues[0] = arg1
+
+	ret.SetReturn(listvalues)
+
+	ln.Push(ret)
+	expected.Root = ln
+
+	parserTestTable("return", `return "value"`, expected, t, true)
 }
 
 func TestParseIfInvalid(t *testing.T) {

--- a/parse_util_test.go
+++ b/parse_util_test.go
@@ -340,6 +340,30 @@ func compareFnDeclNode(expected, value *FnDeclNode) (bool, error) {
 	return compare(expected.Tree(), value.Tree())
 }
 
+func compareReturnNode(expected, value *ReturnNode) (bool, error) {
+	if ok, err := compareDefault(expected, value); !ok {
+		return ok, err
+	}
+
+	erets := expected.Return()
+	vrets := value.Return()
+
+	if len(erets) != len(vrets) {
+		return false, fmt.Errorf("compareReturnNode(%v, %v) -> Length differs (%d) != (%d)", expected, value, len(erets), len(vrets))
+	}
+
+	for i := 0; i < len(erets); i++ {
+		eret := erets[i]
+		vret := vrets[i]
+
+		if ok, err := compareArg(eret, vret); !ok {
+			return ok, err
+		}
+	}
+
+	return true, nil
+}
+
 func compareDumpNode(expected, value *DumpNode) (bool, error) {
 	if ok, err := compareDefault(expected, value); !ok {
 		return ok, err
@@ -532,6 +556,10 @@ func compareNodes(expected Node, value Node) (bool, error) {
 		ec := expected.(*DumpNode)
 		vc := value.(*DumpNode)
 		valid, err = compareDumpNode(ec, vc)
+	case *ReturnNode:
+		ec := expected.(*ReturnNode)
+		vc := value.(*ReturnNode)
+		valid, err = compareReturnNode(ec, vc)
 	default:
 		return false, fmt.Errorf("Type %v not comparable yet", v)
 	}

--- a/spec.ebnf
+++ b/spec.ebnf
@@ -49,10 +49,13 @@ forDecl = "for" ( identifier | list ) "{" program "}" .
 
 /* Function declaration */
 fnDecl = "fn" identifier "(" fnArgs ")" "{"
-         program [ "return" ( variable | string_lit | list ) ]
+         program [ returnDecl ]
          "}" .
 fnArgs = { fnArg [ "," ] } .
 fnArg  = identifier .
+
+/* return declaration */
+returnDecl = "return" [ ( variable | string_lit | list ) ] .
 
 /* Function invocation */
 fnInv = identifier "(" fnArgs ")" .


### PR DESCRIPTION
Add return statement to function declaration.

Not it's possible to:

```sh
fn getdirs(path) {
        directories <= ls $path
        return $directories
}

dirs <= getdirs("/")
echo $dirs
```

Output:
```
amd64
bin
boot
data
dev
etc
home
ipfs
ipns
lib
lib64
lost+found
mnt
n
opt
proc
root
run
sbin
srv
sys
tmp
usr
var
```
