### PR TITLE
Separate API for sub shells

### DIFF
--- a/cmd/nash/main.go
+++ b/cmd/nash/main.go
@@ -122,11 +122,13 @@ func getnashpath() (string, error) {
 }
 
 func initShell() (*nash.Shell, error) {
-	shell, err := nash.NewShell(debug)
+	shell, err := nash.NewShell()
 
 	if err != nil {
 		return nil, err
 	}
+
+	shell.SetDebug(debug)
 
 	nashpath, err := getnashpath()
 

--- a/nash.go
+++ b/nash.go
@@ -89,12 +89,11 @@ const (
 )
 
 // NewShell creates a new shell object
-func NewShell(debug bool) (*Shell, error) {
+func NewShell() (*Shell, error) {
 	sh := &Shell{
 		name:      "parent scope",
 		isFn:      false,
-		debug:     debug,
-		log:       NewLog(logNS, debug),
+		log:       NewLog(logNS, false),
 		nashdPath: nashdAutoDiscover(),
 		stdout:    os.Stdout,
 		stderr:    os.Stderr,
@@ -161,6 +160,12 @@ func (sh *Shell) Reset() {
 	sh.vars = make(Var)
 	sh.env = make(Env)
 	sh.binds = make(Fns)
+}
+
+// SetDebug enable/disable debug in the shell
+func (sh *Shell) SetDebug(d bool) {
+	sh.debug = d
+	sh.log = NewLog(logNS, d)
 }
 
 func (sh *Shell) SetName(a string) {
@@ -249,11 +254,6 @@ func (sh *Shell) Prompt() string {
 	}
 
 	return "<no prompt> "
-}
-
-// SetDebug enable/disable debug in the shell
-func (sh *Shell) SetDebug(debug bool) {
-	sh.log = NewLog(logNS, debug)
 }
 
 // SetNashdPath sets an alternativa path to nashd
@@ -1329,12 +1329,13 @@ func (sh *Shell) executeFor(n *ForNode) error {
 }
 
 func (sh *Shell) executeFnDecl(n *FnDeclNode) error {
-	fn, err := NewShell(sh.debug)
+	fn, err := NewShell()
 
 	if err != nil {
 		return err
 	}
 
+	fn.SetDebug(sh.debug)
 	fn.SetName(n.Name())
 	fn.SetParent(sh)
 	fn.SetStdout(sh.stdout)

--- a/nash_linux_test.go
+++ b/nash_linux_test.go
@@ -50,7 +50,7 @@ func TestExecuteRforkUserNS(t *testing.T) {
 
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -83,7 +83,7 @@ func TestExecuteRforkEnvVars(t *testing.T) {
 		return
 	}
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -112,7 +112,7 @@ func TestExecuteRforkUserNSNested(t *testing.T) {
 
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)

--- a/nash_test.go
+++ b/nash_test.go
@@ -35,7 +35,7 @@ func TestExecuteFile(t *testing.T) {
 
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -59,7 +59,7 @@ func TestExecuteFile(t *testing.T) {
 }
 
 func TestExecuteCommand(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -133,7 +133,7 @@ func TestExecuteCommand(t *testing.T) {
 func TestExecuteAssignment(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -179,7 +179,7 @@ func TestExecuteAssignment(t *testing.T) {
 		return
 	}
 
-	sh, err = NewShell(false)
+	sh, err = NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -201,7 +201,7 @@ func TestExecuteAssignment(t *testing.T) {
 func TestExecuteCmdAssignment(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -247,7 +247,7 @@ func TestExecuteCmdAssignment(t *testing.T) {
 		return
 	}
 
-	sh, err = NewShell(false)
+	sh, err = NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -269,7 +269,7 @@ func TestExecuteCmdAssignment(t *testing.T) {
 func TestExecuteCmdAssignmentIFS(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -361,7 +361,7 @@ for i in $range {
 }
 
 func TestExecuteRedirection(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -393,7 +393,7 @@ func TestExecuteRedirection(t *testing.T) {
 }
 
 func TestExecuteRedirectionMap(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -427,7 +427,7 @@ func TestExecuteRedirectionMap(t *testing.T) {
 func TestExecuteCd(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -512,7 +512,7 @@ func TestExecuteCd(t *testing.T) {
 func TestExecuteImport(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -547,7 +547,7 @@ func TestExecuteImport(t *testing.T) {
 func TestExecuteShowEnv(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -592,7 +592,7 @@ func TestExecuteShowEnv(t *testing.T) {
 func TestExecuteIfEqual(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -638,7 +638,7 @@ func TestExecuteIfEqual(t *testing.T) {
 func TestExecuteIfElse(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -688,7 +688,7 @@ func TestExecuteIfElse(t *testing.T) {
 func TestExecuteIfElseIf(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -736,7 +736,7 @@ func TestExecuteIfElseIf(t *testing.T) {
 }
 
 func TestExecuteFnDecl(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -757,7 +757,7 @@ func TestExecuteFnDecl(t *testing.T) {
 }
 
 func TestExecuteFnInv(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -829,7 +829,7 @@ echo -n $INSIDE
 }
 
 func TestExecuteFnInvOthers(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -871,7 +871,7 @@ echo -n $integers
 func TestExecuteBindFn(t *testing.T) {
 	var out bytes.Buffer
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -908,7 +908,7 @@ func TestExecutePipe(t *testing.T) {
 
 	os.Setenv("PATH", path)
 
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -957,7 +957,7 @@ func TestExecuteTCPRedirection(t *testing.T) {
 	done := make(chan bool)
 
 	go func() {
-		sh, err := NewShell(false)
+		sh, err := NewShell()
 
 		if err != nil {
 			t.Error(err)
@@ -1035,7 +1035,7 @@ func TestExecuteUnixRedirection(t *testing.T) {
 			writeDone <- true
 		}()
 
-		sh, err := NewShell(false)
+		sh, err := NewShell()
 
 		if err != nil {
 			t.Error(err)
@@ -1101,7 +1101,7 @@ func TestExecuteUDPRedirection(t *testing.T) {
 			writeDone <- true
 		}()
 
-		sh, err := NewShell(false)
+		sh, err := NewShell()
 
 		if err != nil {
 			t.Error(err)
@@ -1159,7 +1159,7 @@ func TestExecuteUDPRedirection(t *testing.T) {
 }
 
 func TestExecuteReturn(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -1185,7 +1185,7 @@ test()`)
 }
 
 func TestExecuteFnAsFirstClass(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -1224,7 +1224,7 @@ func TestExecuteFnAsFirstClass(t *testing.T) {
 }
 
 func TestExecuteDump(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -1317,7 +1317,7 @@ func TestExecuteDump(t *testing.T) {
 }
 
 func TestExecuteDumpVariable(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -1384,7 +1384,7 @@ func TestExecuteDumpVariable(t *testing.T) {
 }
 
 func TestExecuteConcat(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -1415,7 +1415,7 @@ echo -n $c`)
 }
 
 func TestExecuteFor(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -1453,7 +1453,7 @@ loop`
 }
 
 func TestExecuteInfiniteLoop(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)
@@ -1489,7 +1489,7 @@ func TestExecuteInfiniteLoop(t *testing.T) {
 }
 
 func TestExecuteVariableIndexing(t *testing.T) {
-	sh, err := NewShell(false)
+	sh, err := NewShell()
 
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Create a separate API to create sub shells to avoid issues with locking and signal handling.

Closes #59 