### PR TITLE
Add builtin keyword

### DIFF
--- a/node.go
+++ b/node.go
@@ -188,7 +188,7 @@ type (
 	BuiltinNode struct {
 		NodeType
 		Pos
-		node Node
+		stmt Node
 	}
 )
 
@@ -1114,10 +1114,14 @@ func NewBuiltinNode(pos Pos, n Node) *BuiltinNode {
 	return &BuiltinNode{
 		NodeType: NodeBuiltin,
 		Pos:      pos,
-		node:     n,
+		stmt:     n,
 	}
 }
 
 func (n *BuiltinNode) String() string {
-	return "builtin " + n.node.String()
+	return "builtin " + n.stmt.String()
+}
+
+func (n *BuiltinNode) Stmt() Node {
+	return n.stmt
 }

--- a/node.go
+++ b/node.go
@@ -184,6 +184,12 @@ type (
 		inVar      string
 		tree       *Tree
 	}
+
+	BuiltinNode struct {
+		NodeType
+		Pos
+		node Node
+	}
 )
 
 //go:generate stringer -type=NodeType
@@ -248,6 +254,9 @@ const (
 
 	// NodeFor is the type for "for" statements
 	NodeFor
+
+	// NodeBuiltin
+	NodeBuiltin
 )
 
 //go:generate stringer -type=ArgType
@@ -1098,4 +1107,17 @@ func (n *ForNode) String() string {
 	ret += "}"
 
 	return ret
+}
+
+// NewBuiltinNode creates a new "builtin" node
+func NewBuiltinNode(pos Pos, n Node) *BuiltinNode {
+	return &BuiltinNode{
+		NodeType: NodeBuiltin,
+		Pos:      pos,
+		node:     n,
+	}
+}
+
+func (n *BuiltinNode) String() string {
+	return "builtin " + n.node.String()
 }

--- a/spec.ebnf
+++ b/spec.ebnf
@@ -24,9 +24,12 @@ redirect    = ( ">" ( filename | uri | variable ) |
                ">" "[" unicode_digit "=" "]" ) .
 
 /* Builtin */
-builtin = importDecl | rforkDecl | cdDecl | ifDecl |
+builtin = builtinDecl | importDecl | rforkDecl | cdDecl | ifDecl |
           forDecl | setenvDecl | showenvDecl |
           fnDecl | fnInv | bindfn | dump .
+
+/* builtin only supported for "cd" by now.. */
+builtinDecl = "builtin" cdDecl .
 
 /* Import statement */
 importDecl = "import" ( filename | string_lit ) .


### PR DESCRIPTION
The builtin keyword was added (much like rc builtin) to force the use of a builtin keyword when overrided by bindfn. Now bindfn have scope in the same way as variables.

Then, to override "cd", the *only* way to avoid an infinite loop now is using the "builtin":

```
fn cd(path) {
    builtin cd $path
}

bindfn cd cd
```
