### PR TITLE
Add support for multiline commands and assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,8 @@ Long commands can be splited in multiple lines:
 			--security-groups my-sg
     | jq ".Instances[0].InstanceId"
 )
-```
-
 λ> echo $instanceId
+```
 
 # Namespace features
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,25 @@ For example, trying to evaluate an unbound variable aborts the program with erro
 ERROR: Variable '$bleh' not set
 ```
 
+Long commands can spawn multiple lines:
+
+```sh
+λ> (aws ec2 attach-internet-gateway 	--internet-gateway-id $igwid
+									--vpc-id $vpcid)
+
+λ> instanceId <= (
+	aws ec2 run-instances
+			--image-id ami-xxxxxxxx
+			--count 1
+			--instance-type t1.micro
+			--key-name MyKeyPair
+			--security-groups my-sg
+    | jq ".Instances[0].InstanceId"
+)
+```
+
+λ> echo $instanceId
+
 # Namespace features
 
 Nash is built with namespace support only on Linux (Plan9 soon). If

--- a/README.md
+++ b/README.md
@@ -282,11 +282,17 @@ See the project [nash-app-example](https://github.com/NeowayLabs/nash-app-exampl
 
 I've tested in the following environments:
 
-    Linux 4.1.13 (amd64)
-    Fedora release 23
+    Linux 4.7-rc7
+    Archlinux
+
+    Linux 4.5.5 (amd64)
+    Archlinux
 
     Linux 4.3.3 (amd64)
     Archlinux
+
+    Linux 4.1.13 (amd64)
+    Fedora release 23
 
     Linux 4.1.13 (amd64)
     Debian 8

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ ERROR: Variable '$bleh' not set
 Long commands can be splited in multiple lines:
 
 ```sh
-λ> (aws ec2 attach-internet-gateway 	--internet-gateway-id $igwid
+λ> (aws ec2 attach-internet-gateway	--internet-gateway-id $igwid
 									--vpc-id $vpcid)
 
 λ> instanceId <= (

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ For example, trying to evaluate an unbound variable aborts the program with erro
 ERROR: Variable '$bleh' not set
 ```
 
-Long commands can spawn multiple lines:
+Long commands can be splited in multiple lines:
 
 ```sh
 λ> (aws ec2 attach-internet-gateway 	--internet-gateway-id $igwid
@@ -365,17 +365,20 @@ limitations in mind.
 
 # Motivation
 
-I needed to create test scripts to be running on different mount namespaces
-for testing a file server and various use cases. Using bash in addition to
-docker or rkt was not so good for various reasons. First, docker prior to version 1.10
-doesn't support user namespaces, and then my `make test` would requires root privileges,
-but for docker 1.10 user namespace works still requires to it being enabled in the
-daemon flags (--userns-remap=?) making more hard to work on standard CIs (travis, circle, etc)...
-Another problem was that it was hard to maintain a script, that spawn docker container
-scripts inheriting environment variables from parent namespace (or host). Docker treats the container as a different
-machine or VM, even calling the parent namespace as "host". This breaks the namespace
-sharing/unsharing idea of processes. What I wanted was a copy of the missing plan9
-environment namespace to child namespaces.
+I needed to create test scripts to be running on different mount
+namespaces for testing a file server and various use cases. Using bash
+in addition to docker or rkt was not so good for various
+reasons. First, docker prior to version 1.10 doesn't support user
+namespaces, and then my `make test` would requires root privileges,
+but for docker 1.10 user namespace works still requires to it being
+enabled in the daemon flags (--userns-remap=?) making more hard to
+work on standard CIs (travis, circle, etc)...  Another problem was
+that it was hard to maintain a script, that spawn docker containers
+inheriting environment variables from parent namespace (or
+host). Docker treats the container as a different machine or VM, even
+calling the parent namespace as "host". This breaks the namespace
+sharing/unsharing idea of processes. What I wanted was a copy of the
+missing plan9 'environment namespace' to child namespaces.
 
 # Want to contribute?
 

--- a/ast/node.go
+++ b/ast/node.go
@@ -680,12 +680,13 @@ func (n *CommandNode) IsEqual(other Node) bool {
 }
 
 func (n *CommandNode) multiString() string {
-	var content []string
+	var (
+		content  []string
+		line     string
+		last     = len(n.args) - 1
+		totalLen = 0
+	)
 
-	last := len(n.args) - 1
-
-	line := ""
-	totalLen := 0
 	for i := 0; i < len(n.args); i += 2 {
 		var next string
 

--- a/errors/error.go
+++ b/errors/error.go
@@ -12,12 +12,21 @@ type (
 		format string
 	}
 
+	unfinished struct{}
+
 	unfinishedBlockError struct {
 		*NashError
+		unfinished
 	}
 
 	unfinishedListError struct {
 		*NashError
+		unfinished
+	}
+
+	unfinishedCmdError struct {
+		*NashError
+		unfinished
 	}
 )
 
@@ -33,18 +42,25 @@ func (e *NashError) SetReason(format string, arg ...interface{}) {
 
 func (e *NashError) Error() string { return e.reason }
 
+func (e unfinished) Unfinished() bool { return true }
+
 func NewUnfinishedBlockError(name string, it scanner.Token) error {
 	return &unfinishedBlockError{
-		NashError: NewError("%s:%d:%d: Statement's block '{' not finished", name, it.Line(), it.Column()),
+		NashError: NewError("%s:%d:%d: Statement's block '{' not finished",
+			name, it.Line(), it.Column()),
 	}
 }
-
-func (e *unfinishedBlockError) Unfinished() bool { return true }
 
 func NewUnfinishedListError(name string, it scanner.Token) error {
 	return &unfinishedListError{
-		NashError: NewError("%s:%d:%d: List assignment not finished. Found %v", name, it.Line(), it.Column(), it),
+		NashError: NewError("%s:%d:%d: List assignment not finished. Found %v",
+			name, it.Line(), it.Column(), it),
 	}
 }
 
-func (e *unfinishedListError) Unfinished() bool { return true }
+func NewUnfinishedCmdError(name string, it scanner.Token) error {
+	return &unfinishedCmdError{
+		NashError: NewError("%s:%d:%d: Multi-line command not finished. Found %v but expect ')'",
+			name, it.Line(), it.Column(), it),
+	}
+}

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -1704,7 +1704,7 @@ func TestExecuteGracefullyError(t *testing.T) {
 		return
 	}
 
-	expectErr := "someinput.sh:1:1: Unexpected token parsing statement '('"
+	expectErr := "someinput.sh:1:1: Unexpected token EOF. Expecting IDENT or ARG"
 
 	if err.Error() != expectErr {
 		t.Errorf("Expect error: %s, but got: %s", expectErr, err.Error())

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -209,16 +209,26 @@ func (p *Parser) parsePipe(first *ast.CommandNode) (ast.Node, error) {
 }
 
 func (p *Parser) parseCommand(it scanner.Token) (ast.Node, error) {
-	n := ast.NewCommandNode(it.Pos(), it.Value())
+	isMulti := false
+
+	if it.Type() == token.LParen {
+		// multiline command
+		isMulti = true
+
+		it = p.next()
+	}
+
+	if it.Type() != token.Ident && it.Type() != token.Arg {
+		return nil, newParserError(it, p.name, "Unexpected token %v. Expecting IDENT or ARG", it)
+	}
+
+	n := ast.NewCommandNode(it.Pos(), it.Value(), isMulti)
 
 cmdLoop:
 	for {
 		it = p.peek()
 
 		switch it.Type() {
-		case token.Semicolon:
-			p.ignore()
-			break cmdLoop // TODO: remove this label
 		case token.RBrace:
 			break cmdLoop
 		case token.Ident, token.Arg, token.String, token.Number, token.Variable:
@@ -243,6 +253,7 @@ cmdLoop:
 		case token.Pipe:
 			if p.insidePipe {
 				p.next()
+				// TODO(i4k): test against pipes and multiline cmds
 				return n, nil
 			}
 
@@ -259,6 +270,22 @@ cmdLoop:
 
 	if p.insidePipe {
 		p.insidePipe = false
+	}
+
+	it = p.peek()
+
+	if isMulti {
+		if it.Type() != token.RParen {
+			return nil, newParserError(it, p.name, "Unexpected %v. Expecting ')' to finish multi line command", it)
+		}
+
+		p.ignore()
+
+		it = p.peek()
+	}
+
+	if it.Type() == token.Semicolon {
+		p.ignore()
 	}
 
 	return n, nil
@@ -533,31 +560,36 @@ func (p *Parser) parseAssignValue(name scanner.Token) (ast.Node, error) {
 }
 
 func (p *Parser) parseAssignCmdOut(name scanner.Token) (ast.Node, error) {
+	var (
+		exec ast.Node
+		err  error
+	)
+
 	it := p.next()
 
-	if it.Type() != token.Ident {
+	if it.Type() != token.Ident && it.Type() != token.Arg && it.Type() != token.LParen {
 		return nil, errors.NewError("Invalid token %v. Expected command or function invocation", it)
 	}
 
-	nextIt := p.peek()
+	if it.Type() == token.LParen {
+		// command invocation
+		exec, err = p.parseCommand(it)
+	} else {
+		nextIt := p.peek()
 
-	if nextIt.Type() != token.LParen {
-		cmd, err := p.parseCommand(it)
-
-		if err != nil {
-			return nil, err
+		if nextIt.Type() != token.LParen {
+			// it == (Ident || Arg)
+			exec, err = p.parseCommand(it)
+		} else {
+			exec, err = p.parseFnInv(it)
 		}
-
-		return ast.NewExecAssignNode(name.Pos(), name.Value(), cmd)
 	}
-
-	fn, err := p.parseFnInv(it)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return ast.NewExecAssignNode(name.Pos(), name.Value(), fn)
+	return ast.NewExecAssignNode(name.Pos(), name.Value(), exec)
 }
 
 func (p *Parser) parseRfork(it scanner.Token) (ast.Node, error) {
@@ -1062,6 +1094,12 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 
 		return p.parseCommand(it)
 	} else if it.Type() == token.Arg {
+		return p.parseCommand(it)
+	}
+
+	// statement starting with '('
+	// -multiline command (echo hello)
+	if it.Type() == token.LParen {
 		return p.parseCommand(it)
 	}
 

--- a/parser/parse_regression_test.go
+++ b/parser/parse_regression_test.go
@@ -29,7 +29,7 @@ func TestParseIssue22(t *testing.T) {
 	ifTree := ast.NewTree("if")
 	ifBlock := ast.NewListNode()
 
-	cdNode := ast.NewCommandNode(36, "cd")
+	cdNode := ast.NewCommandNode(36, "cd", false)
 	arg := ast.NewVarExpr(39, "$GOPATH")
 	cdNode.AddArg(arg)
 
@@ -45,7 +45,7 @@ func TestParseIssue22(t *testing.T) {
 	args[1] = ast.NewStringExpr(0, "/src/", true)
 	args[2] = ast.NewVarExpr(0, "$path")
 
-	cdNodeElse := ast.NewCommandNode(0, "cd")
+	cdNodeElse := ast.NewCommandNode(0, "cd", false)
 	carg := ast.NewConcatExpr(0, args)
 	cdNodeElse.AddArg(carg)
 
@@ -108,7 +108,7 @@ func TestParseIssue43(t *testing.T) {
 	fnTree := ast.NewTree("fn")
 	fnBlock := ast.NewListNode()
 
-	gitRevParse := ast.NewCommandNode(24, "git")
+	gitRevParse := ast.NewCommandNode(24, "git", false)
 
 	gitRevParse.AddArg(ast.NewStringExpr(28, "rev-parse", true))
 	gitRevParse.AddArg(ast.NewStringExpr(38, "--abbrev-ref", false))
@@ -121,7 +121,7 @@ func TestParseIssue43(t *testing.T) {
 		return
 	}
 
-	xargs := ast.NewCommandNode(58, "xargs")
+	xargs := ast.NewCommandNode(58, "xargs", false)
 	xargs.AddArg(ast.NewStringExpr(64, "echo", false))
 	xargs.AddArg(ast.NewStringExpr(69, "-n", false))
 
@@ -133,7 +133,7 @@ func TestParseIssue43(t *testing.T) {
 
 	fnBlock.Push(branchAssign)
 
-	gitPull := ast.NewCommandNode(73, "git")
+	gitPull := ast.NewCommandNode(73, "git", false)
 
 	gitPull.AddArg(ast.NewStringExpr(77, "pull", false))
 	gitPull.AddArg(ast.NewStringExpr(82, "origin", false))
@@ -157,12 +157,12 @@ func TestParseIssue68(t *testing.T) {
 	expected := ast.NewTree("parse issue #68")
 	ln := ast.NewListNode()
 
-	catCmd := ast.NewCommandNode(0, "cat")
+	catCmd := ast.NewCommandNode(0, "cat", false)
 
 	catArg := ast.NewStringExpr(4, "PKGBUILD", false)
 	catCmd.AddArg(catArg)
 
-	sedCmd := ast.NewCommandNode(15, "sed")
+	sedCmd := ast.NewCommandNode(15, "sed", false)
 	sedArg := ast.NewStringExpr(20, `s#\$pkgdir#/home/i4k/alt#g`, true)
 	sedCmd.AddArg(sedArg)
 

--- a/parser/parse_regression_test.go
+++ b/parser/parse_regression_test.go
@@ -125,7 +125,7 @@ func TestParseIssue43(t *testing.T) {
 	xargs.AddArg(ast.NewStringExpr(64, "echo", false))
 	xargs.AddArg(ast.NewStringExpr(69, "-n", false))
 
-	pipe := ast.NewPipeNode(56)
+	pipe := ast.NewPipeNode(56, false)
 	pipe.AddCmd(gitRevParse)
 	pipe.AddCmd(xargs)
 
@@ -171,7 +171,7 @@ func TestParseIssue68(t *testing.T) {
 	sedRedir.SetLocation(sedRedirArg)
 	sedCmd.AddRedirect(sedRedir)
 
-	pipe := ast.NewPipeNode(13)
+	pipe := ast.NewPipeNode(13, false)
 	pipe.AddCmd(catCmd)
 	pipe.AddCmd(sedCmd)
 

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -50,7 +51,7 @@ But got:
 func TestParseSimple(t *testing.T) {
 	expected := ast.NewTree("parser simple")
 	ln := ast.NewListNode()
-	cmd := ast.NewCommandNode(0, "echo")
+	cmd := ast.NewCommandNode(0, "echo", false)
 	cmd.AddArg(ast.NewStringExpr(6, "hello world", true))
 	ln.Push(cmd)
 
@@ -58,7 +59,7 @@ func TestParseSimple(t *testing.T) {
 
 	parserTestTable("parser simple", `echo "hello world"`, expected, t, true)
 
-	cmd1 := ast.NewCommandNode(0, "cat")
+	cmd1 := ast.NewCommandNode(0, "cat", false)
 	arg1 := ast.NewStringExpr(4, "/etc/resolv.conf", false)
 	arg2 := ast.NewStringExpr(12, "/etc/hosts", false)
 	cmd1.AddArg(arg1)
@@ -90,10 +91,10 @@ func TestParseReverseGetSame(t *testing.T) {
 func TestParsePipe(t *testing.T) {
 	expected := ast.NewTree("parser pipe")
 	ln := ast.NewListNode()
-	first := ast.NewCommandNode(0, "echo")
+	first := ast.NewCommandNode(0, "echo", false)
 	first.AddArg(ast.NewStringExpr(6, "hello world", true))
 
-	second := ast.NewCommandNode(21, "awk")
+	second := ast.NewCommandNode(21, "awk", false)
 	second.AddArg(ast.NewStringExpr(26, "{print $1}", true))
 
 	pipe := ast.NewPipeNode(19)
@@ -194,7 +195,7 @@ func TestParseCmdAssignment(t *testing.T) {
 	expected := ast.NewTree("simple cmd assignment")
 	ln := ast.NewListNode()
 
-	cmd := ast.NewCommandNode(8, "ls")
+	cmd := ast.NewCommandNode(8, "ls", false)
 
 	assign, err := ast.NewExecAssignNode(0, "test", cmd)
 
@@ -223,7 +224,7 @@ func TestParseInvalid(t *testing.T) {
 func TestParsePathCommand(t *testing.T) {
 	expected := ast.NewTree("parser simple")
 	ln := ast.NewListNode()
-	cmd := ast.NewCommandNode(0, "/bin/echo")
+	cmd := ast.NewCommandNode(0, "/bin/echo", false)
 	cmd.AddArg(ast.NewStringExpr(11, "hello world", true))
 	ln.Push(cmd)
 
@@ -236,7 +237,7 @@ func TestParseWithShebang(t *testing.T) {
 	expected := ast.NewTree("parser shebang")
 	ln := ast.NewListNode()
 	cmt := ast.NewCommentNode(0, "#!/bin/nash")
-	cmd := ast.NewCommandNode(12, "echo")
+	cmd := ast.NewCommandNode(12, "echo", false)
 	cmd.AddArg(ast.NewStringExpr(17, "bleh", false))
 	ln.Push(cmt)
 	ln.Push(cmd)
@@ -260,7 +261,7 @@ func TestParseEmptyFile(t *testing.T) {
 func TestParseSingleCommand(t *testing.T) {
 	expected := ast.NewTree("single command")
 	expected.Root = ast.NewListNode()
-	expected.Root.Push(ast.NewCommandNode(0, "bleh"))
+	expected.Root.Push(ast.NewCommandNode(0, "bleh", false))
 
 	parserTestTable("single command", `bleh`, expected, t, true)
 }
@@ -268,7 +269,7 @@ func TestParseSingleCommand(t *testing.T) {
 func TestParseRedirectSimple(t *testing.T) {
 	expected := ast.NewTree("redirect")
 	ln := ast.NewListNode()
-	cmd := ast.NewCommandNode(0, "cmd")
+	cmd := ast.NewCommandNode(0, "cmd", false)
 	redir := ast.NewRedirectNode(0)
 	redir.SetMap(2, ast.RedirMapSupress)
 	cmd.AddRedirect(redir)
@@ -280,7 +281,7 @@ func TestParseRedirectSimple(t *testing.T) {
 
 	expected = ast.NewTree("redirect2")
 	ln = ast.NewListNode()
-	cmd = ast.NewCommandNode(0, "cmd")
+	cmd = ast.NewCommandNode(0, "cmd", false)
 	redir = ast.NewRedirectNode(0)
 	redir.SetMap(2, 1)
 	cmd.AddRedirect(redir)
@@ -294,7 +295,7 @@ func TestParseRedirectSimple(t *testing.T) {
 func TestParseRedirectWithLocation(t *testing.T) {
 	expected := ast.NewTree("redirect with location")
 	ln := ast.NewListNode()
-	cmd := ast.NewCommandNode(0, "cmd")
+	cmd := ast.NewCommandNode(0, "cmd", false)
 	redir := ast.NewRedirectNode(0)
 	redir.SetMap(2, ast.RedirMapNoValue)
 	redir.SetLocation(ast.NewStringExpr(0, "/var/log/service.log", false))
@@ -309,7 +310,7 @@ func TestParseRedirectWithLocation(t *testing.T) {
 func TestParseRedirectMultiples(t *testing.T) {
 	expected := ast.NewTree("redirect multiples")
 	ln := ast.NewListNode()
-	cmd := ast.NewCommandNode(0, "cmd")
+	cmd := ast.NewCommandNode(0, "cmd", false)
 	redir1 := ast.NewRedirectNode(0)
 	redir2 := ast.NewRedirectNode(0)
 
@@ -328,8 +329,8 @@ func TestParseRedirectMultiples(t *testing.T) {
 func TestParseCommandWithStringsEqualsNot(t *testing.T) {
 	expected := ast.NewTree("strings works as expected")
 	ln := ast.NewListNode()
-	cmd1 := ast.NewCommandNode(0, "echo")
-	cmd2 := ast.NewCommandNode(11, "echo")
+	cmd1 := ast.NewCommandNode(0, "echo", false)
+	cmd2 := ast.NewCommandNode(11, "echo", false)
 	cmd1.AddArg(ast.NewStringExpr(5, "hello", false))
 	cmd2.AddArg(ast.NewStringExpr(17, "hello", true))
 
@@ -360,7 +361,7 @@ func TestParseStringNotFinished(t *testing.T) {
 func TestParseCd(t *testing.T) {
 	expected := ast.NewTree("test cd")
 	ln := ast.NewListNode()
-	cd := ast.NewCommandNode(0, "cd")
+	cd := ast.NewCommandNode(0, "cd", false)
 	arg := ast.NewStringExpr(3, "/tmp", false)
 	cd.AddArg(arg)
 	ln.Push(cd)
@@ -371,7 +372,7 @@ func TestParseCd(t *testing.T) {
 	// test cd into home
 	expected = ast.NewTree("test cd into home")
 	ln = ast.NewListNode()
-	cd = ast.NewCommandNode(0, "cd")
+	cd = ast.NewCommandNode(0, "cd", false)
 	ln.Push(cd)
 	expected.Root = ln
 
@@ -383,8 +384,8 @@ func TestParseCd(t *testing.T) {
 	assign := ast.NewAssignmentNode(0, "HOME", ast.NewStringExpr(8, "/", true))
 
 	set := ast.NewSetenvNode(11, "HOME")
-	cd = ast.NewCommandNode(23, "cd")
-	pwd := ast.NewCommandNode(26, "pwd")
+	cd = ast.NewCommandNode(23, "cd", false)
+	pwd := ast.NewCommandNode(26, "pwd", false)
 
 	ln.Push(assign)
 	ln.Push(set)
@@ -405,7 +406,7 @@ pwd`, expected, t, true)
 	arg = ast.NewStringExpr(10, "/home/i4k/gopath", true)
 
 	assign = ast.NewAssignmentNode(0, "GOPATH", arg)
-	cd = ast.NewCommandNode(28, "cd")
+	cd = ast.NewCommandNode(28, "cd", false)
 	arg2 := ast.NewVarExpr(31, "$GOPATH")
 	cd.AddArg(arg2)
 
@@ -429,7 +430,7 @@ cd $GOPATH`, expected, t, true)
 	concat = append(concat, ast.NewVarExpr(31, "$GOPATH"))
 	concat = append(concat, ast.NewStringExpr(40, "/src/github.com", true))
 
-	cd = ast.NewCommandNode(28, "cd")
+	cd = ast.NewCommandNode(28, "cd", false)
 	carg := ast.NewConcatExpr(31, concat)
 	cd.AddArg(carg)
 
@@ -462,7 +463,7 @@ func TestParseRforkWithBlock(t *testing.T) {
 	arg := ast.NewStringExpr(6, "u", false)
 	rfork.SetFlags(arg)
 
-	insideFork := ast.NewCommandNode(11, "mount")
+	insideFork := ast.NewCommandNode(11, "mount", false)
 	insideFork.AddArg(ast.NewStringExpr(17, "-t", false))
 	insideFork.AddArg(ast.NewStringExpr(20, "proc", false))
 	insideFork.AddArg(ast.NewStringExpr(25, "proc", false))
@@ -523,7 +524,7 @@ func TestParseIf(t *testing.T) {
 	ifDecl.SetOp("==")
 
 	subBlock := ast.NewListNode()
-	cmd := ast.NewCommandNode(24, "pwd")
+	cmd := ast.NewCommandNode(24, "pwd", false)
 	subBlock.Push(cmd)
 
 	ifTree := ast.NewTree("if block")
@@ -546,7 +547,7 @@ func TestParseIf(t *testing.T) {
 	ifDecl.SetOp("!=")
 
 	subBlock = ast.NewListNode()
-	cmd = ast.NewCommandNode(20, "pwd")
+	cmd = ast.NewCommandNode(20, "pwd", false)
 	subBlock.Push(cmd)
 
 	ifTree = ast.NewTree("if block")
@@ -571,7 +572,7 @@ func TestParseIfLvariable(t *testing.T) {
 	ifDecl.SetOp("==")
 
 	subBlock := ast.NewListNode()
-	cmd := ast.NewCommandNode(23, "pwd")
+	cmd := ast.NewCommandNode(23, "pwd", false)
 	subBlock.Push(cmd)
 
 	ifTree := ast.NewTree("if block")
@@ -596,7 +597,7 @@ func TestParseIfElse(t *testing.T) {
 	ifDecl.SetOp("==")
 
 	subBlock := ast.NewListNode()
-	cmd := ast.NewCommandNode(23, "pwd")
+	cmd := ast.NewCommandNode(23, "pwd", false)
 	subBlock.Push(cmd)
 
 	ifTree := ast.NewTree("if block")
@@ -605,7 +606,7 @@ func TestParseIfElse(t *testing.T) {
 	ifDecl.SetIfTree(ifTree)
 
 	elseBlock := ast.NewListNode()
-	exitCmd := ast.NewCommandNode(0, "exit")
+	exitCmd := ast.NewCommandNode(0, "exit", false)
 	elseBlock.Push(exitCmd)
 
 	elseTree := ast.NewTree("else block")
@@ -632,7 +633,7 @@ func TestParseIfElseIf(t *testing.T) {
 	ifDecl.SetOp("==")
 
 	subBlock := ast.NewListNode()
-	cmd := ast.NewCommandNode(23, "pwd")
+	cmd := ast.NewCommandNode(23, "pwd", false)
 	subBlock.Push(cmd)
 
 	ifTree := ast.NewTree("if block")
@@ -647,7 +648,7 @@ func TestParseIfElseIf(t *testing.T) {
 	elseIfDecl.SetOp("==")
 
 	elseIfBlock := ast.NewListNode()
-	elseifCmd := ast.NewCommandNode(25, "ls")
+	elseifCmd := ast.NewCommandNode(25, "ls", false)
 	elseIfBlock.Push(elseifCmd)
 
 	elseIfTree := ast.NewTree("if block")
@@ -656,7 +657,7 @@ func TestParseIfElseIf(t *testing.T) {
 	elseIfDecl.SetIfTree(elseIfTree)
 
 	elseBlock := ast.NewListNode()
-	exitCmd := ast.NewCommandNode(0, "exit")
+	exitCmd := ast.NewCommandNode(0, "exit", false)
 	elseBlock.Push(exitCmd)
 
 	elseTree := ast.NewTree("else block")
@@ -710,7 +711,7 @@ func TestParseFnBasic(t *testing.T) {
 	fn = ast.NewFnDeclNode(0, "build")
 	tree = ast.NewTree("fn body")
 	lnBody = ast.NewListNode()
-	cmd := ast.NewCommandNode(14, "ls")
+	cmd := ast.NewCommandNode(14, "ls", false)
 	lnBody.Push(cmd)
 	tree.Root = lnBody
 	fn.SetTree(tree)
@@ -732,7 +733,7 @@ func TestParseFnBasic(t *testing.T) {
 	fn.AddArg("image")
 	tree = ast.NewTree("fn body")
 	lnBody = ast.NewListNode()
-	cmd = ast.NewCommandNode(19, "ls")
+	cmd = ast.NewCommandNode(19, "ls", false)
 	lnBody.Push(cmd)
 	tree.Root = lnBody
 	fn.SetTree(tree)
@@ -755,7 +756,7 @@ func TestParseFnBasic(t *testing.T) {
 	fn.AddArg("debug")
 	tree = ast.NewTree("fn body")
 	lnBody = ast.NewListNode()
-	cmd = ast.NewCommandNode(26, "ls")
+	cmd = ast.NewCommandNode(26, "ls", false)
 	lnBody.Push(cmd)
 	tree.Root = lnBody
 	fn.SetTree(tree)
@@ -784,7 +785,7 @@ func TestParseRedirectionVariable(t *testing.T) {
 	expected := ast.NewTree("redirection var")
 	ln := ast.NewListNode()
 
-	cmd := ast.NewCommandNode(0, "cmd")
+	cmd := ast.NewCommandNode(0, "cmd", false)
 	redir := ast.NewRedirectNode(0)
 	redirArg := ast.NewVarExpr(0, "$outFname")
 	redir.SetLocation(redirArg)
@@ -934,4 +935,66 @@ func TestParseVariableIndexing(t *testing.T) {
 	parserTestTable("variable indexing", `if $values[0] == "1" {
 
 }`, expected, t, true)
+}
+
+func TestParseMultilineCmdExec(t *testing.T) {
+	expected := ast.NewTree("parser simple")
+	ln := ast.NewListNode()
+	cmd := ast.NewCommandNode(0, "echo", true)
+	cmd.AddArg(ast.NewStringExpr(6, "hello world", true))
+	ln.Push(cmd)
+
+	expected.Root = ln
+
+	parserTestTable("parser simple", `(echo "hello world")`, expected, t, true)
+
+	expected = ast.NewTree("parser aws cmd")
+	ln = ast.NewListNode()
+	cmd = ast.NewCommandNode(0, "aws", true)
+	cmd.AddArg(ast.NewStringExpr(4, "ec2", false))
+	cmd.AddArg(ast.NewStringExpr(8, "run-instances", false))
+	cmd.AddArg(ast.NewStringExpr(22, "--image-id", false))
+	cmd.AddArg(ast.NewStringExpr(33, "ami-xxxxxxxx", false))
+	cmd.AddArg(ast.NewStringExpr(33, "--count", false))
+	cmd.AddArg(ast.NewStringExpr(33, "1", false))
+	cmd.AddArg(ast.NewStringExpr(33, "--instance-type", false))
+	cmd.AddArg(ast.NewStringExpr(33, "t1.micro", false))
+	cmd.AddArg(ast.NewStringExpr(33, "--key-name", false))
+	cmd.AddArg(ast.NewStringExpr(33, "MyKeyPair", false))
+	cmd.AddArg(ast.NewStringExpr(33, "--security-groups", false))
+	cmd.AddArg(ast.NewStringExpr(33, "my-sg", false))
+
+	ln.Push(cmd)
+
+	expected.Root = ln
+
+	fmt.Printf("ToString: '%s'\n", expected.String())
+
+	parserTestTable("parser simple", `(
+	aws ec2 run-instances
+			--image-id ami-xxxxxxxx
+			--count 1
+			--instance-type t1.micro
+			--key-name MyKeyPair
+			--security-groups my-sg
+)`, expected, t, true)
+}
+
+func TestParseMultilineCmdAssign(t *testing.T) {
+	expected := ast.NewTree("parser simple assign")
+	ln := ast.NewListNode()
+	cmd := ast.NewCommandNode(0, "echo", true)
+	cmd.AddArg(ast.NewStringExpr(6, "hello world", true))
+	assign, err := ast.NewExecAssignNode(0, "hello", cmd)
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	ln.Push(assign)
+
+	expected.Root = ln
+
+	parserTestTable("parser simple", `hello <= (echo "hello world")`, expected, t, true)
 }

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -97,7 +97,7 @@ func TestParsePipe(t *testing.T) {
 	second := ast.NewCommandNode(21, "awk", false)
 	second.AddArg(ast.NewStringExpr(26, "{print $1}", true))
 
-	pipe := ast.NewPipeNode(19)
+	pipe := ast.NewPipeNode(19, false)
 	pipe.AddCmd(first)
 	pipe.AddCmd(second)
 
@@ -997,4 +997,46 @@ func TestParseMultilineCmdAssign(t *testing.T) {
 	expected.Root = ln
 
 	parserTestTable("parser simple", `hello <= (echo "hello world")`, expected, t, true)
+}
+
+func TestMultiPipe(t *testing.T) {
+	expected := ast.NewTree("parser pipe")
+	ln := ast.NewListNode()
+	first := ast.NewCommandNode(0, "echo", false)
+	first.AddArg(ast.NewStringExpr(6, "hello world", true))
+
+	second := ast.NewCommandNode(21, "awk", false)
+	second.AddArg(ast.NewStringExpr(26, "{print $1}", true))
+
+	pipe := ast.NewPipeNode(19, true)
+	pipe.AddCmd(first)
+	pipe.AddCmd(second)
+
+	ln.Push(pipe)
+
+	expected.Root = ln
+
+	parserTestTable("parser pipe", `(echo "hello world" | awk "{print $1}")`, expected, t, true)
+
+	// get longer stringify
+	expected = ast.NewTree("parser pipe")
+	ln = ast.NewListNode()
+	first = ast.NewCommandNode(0, "echo", false)
+	first.AddArg(ast.NewStringExpr(6, "hello world", true))
+
+	second = ast.NewCommandNode(21, "awk", false)
+	second.AddArg(ast.NewStringExpr(26, "{print AAAAAAAAAAAAAAAAAAAAAA}", true))
+
+	pipe = ast.NewPipeNode(19, true)
+	pipe.AddCmd(first)
+	pipe.AddCmd(second)
+
+	ln.Push(pipe)
+
+	expected.Root = ln
+
+	parserTestTable("parser pipe", `(
+	echo "hello world" |
+	awk "{print AAAAAAAAAAAAAAAAAAAAAA}"
+)`, expected, t, true)
 }

--- a/scanner/lex_test.go
+++ b/scanner/lex_test.go
@@ -1476,3 +1476,100 @@ func TestLexerListIndexing(t *testing.T) {
 
 	testTable("test if with indexing", `if $crazies[0] == "patito" { echo ":D" }`, expected, t)
 }
+
+func TestLexerMultilineCmdExecution(t *testing.T) {
+	expected := []Token{
+		{typ: token.LParen, val: "("},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("multiline", `()`, expected, t)
+
+	expected = []Token{
+		{typ: token.LParen, val: "("},
+		{typ: token.Ident, val: "echo"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("multiline", `(echo)`, expected, t)
+
+	expected = []Token{
+		{typ: token.LParen, val: "("},
+		{typ: token.Ident, val: "echo"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "BBBBB"},
+		{typ: token.Ident, val: "BBBBB"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("test multiline cmd execution", `(echo AAAAA AAAAA
+	AAAAA AAAAA
+	AAAAA AAAAA
+	BBBBB BBBBB)`, expected, t)
+}
+
+func TestLexerMultilineCmdAssign(t *testing.T) {
+	expected := []Token{
+		{typ: token.Ident, val: "some"},
+		{typ: token.AssignCmd, val: "<="},
+		{typ: token.LParen, val: "("},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("multiline", `some <= ()`, expected, t)
+
+	expected = []Token{
+		{typ: token.Ident, val: "some"},
+		{typ: token.AssignCmd, val: "<="},
+		{typ: token.LParen, val: "("},
+		{typ: token.Ident, val: "echo"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("multiline", `some <= (echo)`, expected, t)
+
+	expected = []Token{
+		{typ: token.Ident, val: "some"},
+		{typ: token.AssignCmd, val: "<="},
+		{typ: token.LParen, val: "("},
+		{typ: token.Ident, val: "echo"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "AAAAA"},
+		{typ: token.Ident, val: "BBBBB"},
+		{typ: token.Ident, val: "BBBBB"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("multiline", `some <= (echo AAAAA AAAAA
+	AAAAA AAAAA
+	AAAAA AAAAA
+	BBBBB BBBBB)`, expected, t)
+
+	testTable("multiline", `some <= (
+	echo AAAAA AAAAA
+	AAAAA AAAAA
+	AAAAA AAAAA
+	BBBBB BBBBB
+)`, expected, t)
+}

--- a/spec.ebnf
+++ b/spec.ebnf
@@ -9,15 +9,15 @@ varDecl      = assignValue | assignCmdOut .
 assignValue  = identifier "=" varSpec .
 varSpec      = ( list | varValue ) .
 varValue     = string_lit | ( stringConcat { stringConcat } ) .
-assignCmdOut = identifier "<=" command .
+assignCmdOut = identifier "<=" ( command | fnInv ) .
 
 /* Command */
-command   = ( cmdpart | pipe ) .
+command   = ( [ "(" ] cmdpart [ ")" ]  | pipe ) .
 cmdpart   = [ "-" ] ( cmdname | abscmd ) { argument } { redirect } .
 cmdname   = identifier .
 abscmd    = filename .
 argument  = ( unicode_char { unicode_char } ) | string_lit .
-pipe      = cmdpart "|" cmdpart [ { "|" cmdpart } ] .
+pipe      = [ "(" ] cmdpart "|" cmdpart [ { "|" cmdpart } ] [ ")" ] .
 redirect    = ( ">" ( filename | uri | variable ) |
                ">" "[" unicode_digit "]" ( filename | uri | variable ) |
                ">" "[" unicode_digit "=" ( unicode_digit | identifier ) "]" |


### PR DESCRIPTION
Added support for multiline command execution.
Usage examples:

```sh
# command execution
λ> (aws ec2 attach-internet-gateway	
				--internet-gateway-id $igwid
				--vpc-id $vpcid)
```

```sh
# pipe execution
λ> (
 	aws ec2 run-instances
 			--image-id ami-xxxxxxxx
			--count 1
			--instance-type t1.micro
			--key-name MyKeyPair
			--security-groups my-sg
    | jq ".Instances[0].InstanceId"
)
```
It could be used in every place a command is expected. In command assignment, for example:

```sh
# Command assignment
λ> instanceId <= (
 	aws ec2 run-instances
 			--image-id ami-xxxxxxxx
			--count 1
			--instance-type t1.micro
			--key-name MyKeyPair
			--security-groups my-sg
    | jq ".Instances[0].InstanceId"
)
λ> echo $instanceId
```

Closes #90 
@lborguetti 