### PR TITLE
Fix panic when formatting pipes

### DIFF
--- a/ast/node_fmt.go
+++ b/ast/node_fmt.go
@@ -246,7 +246,7 @@ func (n *CommandNode) toStringParts() ([]string, int) {
 				line = ""
 			}
 
-			if next[0] != '-' {
+			if len(next) > 0 && next[0] != '-' {
 				if line == "" {
 					line += arg + " " + next
 				} else {


### PR DESCRIPTION
Closes #104 

Now, the code below:

```sh
fn aws_instance_create(imgid, kname, secgrps, type, privip, subnetid) {
    instid <= (
        aws ec2 run-instances
                --image-id
                $imgid --count 1 --key-name kubernetes --security-group-ids $secgrps --instance-type $type --private-ip-address $privip --subnet-id $subnetid
                                                --associate-public-ip-address |
        jq -r ".Instances[].InstanceId"
    )
}
```

is formatted as:

```sh
fn aws_instance_create(imgid, kname, secgrps, type, privip, subnetid) {
	instid <= (
		aws ec2 run-instances
				--image-id $imgid
				--count 1
				--key-name kubernetes
				--security-group-ids $secgrps
				--instance-type $type
				--private-ip-address $privip
				--subnet-id $subnetid
				--associate-public-ip-address
				 |
		jq -r ".Instances[].InstanceId"
	)
}
```