### PR TITLE
parser: Fix a bug in parser not allowing keyword names as command arguments.

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -244,10 +244,10 @@ cmdLoop:
 	for {
 		it = p.peek()
 
-		switch it.Type() {
-		case token.RBrace:
+		switch typ := it.Type(); {
+		case typ == token.RBrace:
 			break cmdLoop
-		case token.Ident, token.Arg, token.String, token.Number, token.Variable:
+		case isValidArgument(it):
 			arg, err := p.getArgument(true, true)
 
 			if err != nil {
@@ -255,9 +255,9 @@ cmdLoop:
 			}
 
 			n.AddArg(arg)
-		case token.Plus:
+		case typ == token.Plus:
 			return nil, errors.NewError("%s:%d:%d: Unexpected '+'", p.name, it.Line(), it.Column())
-		case token.Gt:
+		case typ == token.Gt:
 			p.next()
 			redir, err := p.parseRedirection(it)
 
@@ -266,7 +266,7 @@ cmdLoop:
 			}
 
 			n.AddRedirect(redir)
-		case token.Pipe:
+		case typ == token.Pipe:
 			if p.insidePipe {
 				p.next()
 				// TODO(i4k): test against pipes and multiline cmds
@@ -275,9 +275,9 @@ cmdLoop:
 
 			p.insidePipe = true
 			return p.parsePipe(n)
-		case token.EOF:
+		case typ == token.EOF:
 			break cmdLoop
-		case token.Illegal:
+		case typ == token.Illegal:
 			return nil, errors.NewError(it.Value())
 		default:
 			break cmdLoop

--- a/parser/parse_regression_test.go
+++ b/parser/parse_regression_test.go
@@ -216,3 +216,31 @@ func TestParseImportIssue94(t *testing.T) {
 
 	parserTestTable("test import", "import common", expected, t, true)
 }
+
+func TestParseIssue108(t *testing.T) {
+	// keywords cannot be used as command arguments
+
+	expected := ast.NewTree("parse issue #108")
+	ln := ast.NewBlockNode(token.NewFileInfo(1, 0))
+
+	catCmd := ast.NewCommandNode(token.NewFileInfo(1, 0), "cat", false)
+
+	catArg := ast.NewStringExpr(token.NewFileInfo(1, 4), "spec.ebnf", false)
+	catCmd.AddArg(catArg)
+
+	grepCmd := ast.NewCommandNode(token.NewFileInfo(1, 16), "grep", false)
+	grepArg := ast.NewStringExpr(token.NewFileInfo(1, 21), `-i`, false)
+	grepArg2 := ast.NewStringExpr(token.NewFileInfo(1, 24), "rfork", false)
+
+	grepCmd.AddArg(grepArg)
+	grepCmd.AddArg(grepArg2)
+
+	pipe := ast.NewPipeNode(token.NewFileInfo(1, 14), false)
+	pipe.AddCmd(catCmd)
+	pipe.AddCmd(grepCmd)
+
+	ln.Push(pipe)
+	expected.Root = ln
+
+	parserTestTable("parse issue #108", `cat spec.ebnf | grep -i rfork`, expected, t, false)
+}


### PR DESCRIPTION
The last refactor of parser introduced a bug because the old scanner/lexer was much more aware of the grammar and delivered only high level tokens to parser. But current lexer do not disambiguate tokens. 

The bug was a missing handling of valid tokens for command arguments.

Closes #108 