### PR TITLE
Hack to enable '=' in the middle of command arguments.

### DIFF
--- a/parser/parse.go
+++ b/parser/parse.go
@@ -466,7 +466,31 @@ func (p *Parser) getArgument(allowArg, allowConcat bool) (ast.Expr, error) {
 		arg = ast.NewStringExpr(firstToken.FileInfo, firstToken.Value(), true)
 	} else {
 		// Arg && Ident
-		arg = ast.NewStringExpr(firstToken.FileInfo, firstToken.Value(), false)
+		it = p.peek()
+
+		var argstr string
+
+		if it.Type() == token.Assign &&
+			// check if '=' is close to arg
+			firstToken.Column()+len(firstToken.Value()) == it.Column() {
+			assignIt := p.next()
+
+			it = p.peek()
+
+			if (it.Type() == token.Ident || it.Type() == token.Arg) &&
+				// check if next token "touchs" the '='
+				assignIt.Column()+1 == it.Column() {
+				p.next()
+				argstr = firstToken.Value() + "=" + it.Value()
+			} else {
+				argstr = firstToken.Value() + "="
+			}
+
+		} else {
+			argstr = firstToken.Value()
+		}
+
+		arg = ast.NewStringExpr(firstToken.FileInfo, argstr, false)
 	}
 
 	it = p.peek()

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -1165,3 +1165,26 @@ func TestMultiPipe(t *testing.T) {
 	awk "{print AAAAAAAAAAAAAAAAAAAAAA}"
 )`, expected, t, true)
 }
+
+func TestParseCommandWithEqual(t *testing.T) {
+	expected := ast.NewTree("parser argument containing equal")
+	ln := ast.NewBlockNode(token.NewFileInfo(1, 0))
+	cmd := ast.NewCommandNode(token.NewFileInfo(1, 0), "echo", false)
+	cmd.AddArg(ast.NewStringExpr(token.NewFileInfo(1, 5), "hello=world", false))
+	ln.Push(cmd)
+
+	expected.Root = ln
+
+	parserTestTable("parser simple", `echo hello=world`, expected, t, true)
+
+	expected = ast.NewTree("parser argument containing equal")
+	ln = ast.NewBlockNode(token.NewFileInfo(1, 0))
+	cmd = ast.NewCommandNode(token.NewFileInfo(1, 0), "echo", false)
+	cmd.AddArg(ast.NewStringExpr(token.NewFileInfo(1, 5), "hello=", false))
+	cmd.AddArg(ast.NewStringExpr(token.NewFileInfo(1, 12), "world", false))
+	ln.Push(cmd)
+
+	expected.Root = ln
+
+	parserTestTable("parser simple", `echo hello= world`, expected, t, true)
+}

--- a/scanner/lex.go
+++ b/scanner/lex.go
@@ -341,7 +341,6 @@ func lexStart(l *Lexer) stateFn {
 		l.emit(token.Comma)
 		return lexStart
 	case isIdentifier(r):
-		// nash literals are lowercase
 		absorbIdentifier(l)
 
 		next := l.peek()
@@ -353,6 +352,7 @@ func lexStart(l *Lexer) stateFn {
 			lit := scanIdentifier(l)
 
 			if len(lit) > 1 && r >= 'a' && r <= 'z' {
+				// nash literals are lowercase
 				l.emit(token.Lookup(lit))
 			} else {
 				l.emit(token.Ident)


### PR DESCRIPTION
WIP: PoC to verify alternatives to syntax.

The problem is that '=' cannot be used in command arguments without quoting to avoid the ambiguity below (see issue #114 ):

    ls = "a"

It's a variable assignment? or a 'ls' listing on files '=' and "a"?

Current syntax is very straightforward, you must be explicit about what you're writing. Then, if you want execute listing on files '=' and 'a', you must quote the '='.

    ls "=" a
or
    ls "=" "a"

Otherwise, it's an assignment.

Ok, then?

This commit leaves the problem above as is, but enable '=' in other cases, like below:

    make collection=project1

or

    docker run -e VAR1= -e VAR2= something

But EQUAL is still *prohibited* in the cases below:

    1. make otheroption =something # (solvable)
    2. make otheroption = othervalue # (solvable) 
    3. make = something # (solvable, but only because assignment require quotes in the rhs)
    4. make = "something" # (impossible, this is an assignment by spec...)

1 & 2 are easy.
Solving 3 will make the parser code hard to follow or will require changes in the lexer to emit context to each token.

Maybe this confuses the syntax, and people could be more *surprise* of this behaviour than the enforcement of quoting '=' ... I don't know.

@katcipis @lborguetti @patito What do you guys think? It's a good direction?