### PR TITLE
Improve the parser on several corner cases

### DIFF
--- a/cmd/nashfmt/main.go
+++ b/cmd/nashfmt/main.go
@@ -36,7 +36,7 @@ func main() {
 	file, err = os.Open(fname)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[ERROR] "+err.Error())
+		fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
 		os.Exit(1)
 	}
 
@@ -44,7 +44,7 @@ func main() {
 
 	if err != nil {
 		file.Close()
-		fmt.Fprintf(os.Stderr, "[ERROR] "+err.Error())
+		fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
 		os.Exit(1)
 	}
 
@@ -53,7 +53,7 @@ func main() {
 	ast, err := parser.Parse()
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "[ERROR] "+err.Error())
+		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 		file.Close()
 		os.Exit(1)
 	}
@@ -69,7 +69,7 @@ func main() {
 		err = ioutil.WriteFile(fname, []byte(fmt.Sprintf("%s\n", ast.String())), 0666)
 
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "[ERROR] "+err.Error())
+			fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
 			return
 		}
 	}

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -2041,7 +2041,7 @@ func TestExecuteMultilineCmdAssign(t *testing.T) {
 	}
 }
 
-func TestExecuteMuliReturnUnfinished(t *testing.T) {
+func TestExecuteMultiReturnUnfinished(t *testing.T) {
 	shell, err := NewShell()
 
 	if err != nil {

--- a/parser/parse_regression_test.go
+++ b/parser/parse_regression_test.go
@@ -244,3 +244,20 @@ func TestParseIssue108(t *testing.T) {
 
 	parserTestTable("parse issue #108", `cat spec.ebnf | grep -i rfork`, expected, t, false)
 }
+
+func TestParseIssue123(t *testing.T) {
+	parser := NewParser("invalid cmd assignment", `IFS <= ("\n")`)
+
+	_, err := parser.Parse()
+
+	if err == nil {
+		t.Errorf("Must fail...")
+		return
+	}
+
+	expected := "invalid cmd assignment:1:9: Unexpected token STRING. Expecting IDENT or ARG"
+	if err.Error() != expected {
+		t.Fatalf("Error string differs. Expecting '%s' but got '%s'",
+			expected, err.Error())
+	}
+}

--- a/scanner/lex.go
+++ b/scanner/lex.go
@@ -372,7 +372,11 @@ func lexStart(l *Lexer) stateFn {
 			l.emit(token.Arg)
 		}
 
-		l.addSemicolon = true
+		if next == eof && l.openParens > 0 {
+			l.addSemicolon = false
+		} else {
+			l.addSemicolon = true
+		}
 
 		return lexStart
 	case isArgument(r):

--- a/scanner/lex_test.go
+++ b/scanner/lex_test.go
@@ -484,6 +484,26 @@ func TestLexerPipe(t *testing.T) {
 	testTable("testPipe with redirection", `go tool vet -h > out.log | grep log`, expected, t)
 }
 
+func TestPipeFunctions(t *testing.T) {
+	expected := []Token{
+		{typ: token.Ident, val: "echo"},
+		{typ: token.String, val: "some thing"},
+		{typ: token.Pipe, val: "|"},
+		{typ: token.Ident, val: "replace"},
+		{typ: token.LParen, val: "("},
+		{typ: token.String, val: " "},
+		{typ: token.Comma, val: ","},
+		{typ: token.String, val: "|"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("test pipe with function",
+		`echo "some thing" | replace(" ", "|")`,
+		expected, t)
+}
+
 func TestLexerUnquoteArg(t *testing.T) {
 	expected := []Token{
 		{typ: token.Ident, val: "echo"},


### PR DESCRIPTION
- Forbid use of function call in pipelines

The command below now throws a correct error:

`echo "test test" | replace(" ", "|")`

before this commit, the command above returns a `UnfinishedCmdError` entering the `cli` in multi-line state.

- Improve the error for invalid sintaxes (Closes #123)

