### PR TITLE
Remove IFS variable support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,12 @@ echo $fullpath
 The symbol '<=' redirects the stdout of the command or function invocation in the
 right-hand side to the variable name specified.
 
-If you want the command output splited into an array, use the IFS
-special variable to store the delimiter (like bash, but use a list
-instead of a string).
+If you want the command output splited into an array, then you'll need
+to store it in a temporary variable and then use the builtin `split` function.
 
 ```sh
-IFS = ("\n")
-files <= find .
+out <= find .
+files <= split($out, "\n")
 
 for f in $files {
         echo "File: " + $f

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -411,6 +411,10 @@ func (shell *Shell) setupBuiltin() error {
 	shell.builtins["append"] = appendfn
 	shell.Setvar("append", sh.NewFnObj(appendfn))
 
+	splitfn := NewSplitFn(shell)
+	shell.builtins["split"] = splitfn
+	shell.Setvar("split", sh.NewFnObj(splitfn))
+
 	chdir := NewChdir(shell)
 	shell.builtins["chdir"] = chdir
 	shell.Setvar("chdir", sh.NewFnObj(chdir))
@@ -1488,42 +1492,16 @@ func (shell *Shell) executeExecAssign(v *ast.ExecAssignNode) error {
 		err = errors.NewError("Unexpected node in assignment: %s", assign.String())
 	}
 
-	var strelems []string
+	output := varOut.Bytes()
 
-	outStr := string(varOut.Bytes())
+	if len(output) > 0 && output[len(output)-1] == '\n' {
+		// remove the trailing new line
+		// Why? because it's what user wants in 99% of times...
 
-	if ifs, ok := shell.Getvar("IFS"); ok && ifs.Type() == sh.ListType {
-		ifslist := ifs.(*sh.ListObj)
-
-		if len(ifslist.List()) > 0 {
-			strelems = strings.FieldsFunc(outStr, func(r rune) bool {
-				for _, delim := range ifslist.List() {
-					if delim.Type() != sh.StringType {
-						continue
-					}
-
-					objstr := delim.(*sh.StrObj)
-
-					if len(objstr.Str()) > 0 && rune(objstr.Str()[0]) == r {
-						return true
-					}
-				}
-
-				return false
-			})
-
-			objelems := make([]sh.Obj, len(strelems))
-
-			for i := 0; i < len(strelems); i++ {
-				objelems[i] = sh.NewStrObj(strelems[i])
-			}
-
-			shell.Setvar(v.Identifier(), sh.NewListObj(objelems))
-			return nil
-		}
+		output = output[0 : len(output)-1]
 	}
 
-	shell.Setvar(v.Identifier(), sh.NewStrObj(outStr))
+	shell.Setvar(v.Identifier(), sh.NewStrObj(string(output)))
 
 	return err
 }

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -329,26 +329,8 @@ for i in $range {
     echo "i = " + $i
 }`)
 
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	expected := `i = 1
-i = 2
-i = 3
-i = 4
-i = 5
-i = 6
-i = 7
-i = 8
-i = 9
-i = 10`
-
-	if strings.TrimSpace(string(out.Bytes())) != expected {
-		t.Error("assignment not work")
-		fmt.Printf("'%s' != '%s'\n", strings.TrimSpace(string(out.Bytes())), expected)
-
+	if err == nil {
+		t.Errorf("Must fail. IFS doesn't works anymore")
 		return
 	}
 
@@ -361,10 +343,8 @@ for i in $range {
     echo "i = " + $i
 }`)
 
-	if strings.TrimSpace(string(out.Bytes())) != expected {
-		t.Error("assignment not work")
-		fmt.Printf("'%s' != '%s'\n", strings.TrimSpace(string(out.Bytes())), expected)
-
+	if err == nil {
+		t.Errorf("Must fail. IFS doesn't works anymore")
 		return
 	}
 
@@ -377,10 +357,8 @@ for i in $range {
     echo "i = " + $i
 }`)
 
-	if strings.TrimSpace(string(out.Bytes())) != expected {
-		t.Error("assignment not work")
-		fmt.Printf("'%s' != '%s'\n", strings.TrimSpace(string(out.Bytes())), expected)
-
+	if err == nil {
+		t.Errorf("Must fail. IFS doesn't works anymore")
 		return
 	}
 
@@ -393,14 +371,10 @@ for i in $range {
     echo "i = " + $i
 }`)
 
-	expected = "i = 1;2;3;4;5;6;7;8;9;10"
-
-	if strings.TrimSpace(string(out.Bytes())) != expected {
-		t.Error("assignment not work")
-		fmt.Printf("'%s' != '%s'\n", strings.TrimSpace(string(out.Bytes())), expected)
+	if err == nil {
+		t.Errorf("Must fail. IFS doesn't works anymore")
 		return
 	}
-
 }
 
 func TestExecuteRedirection(t *testing.T) {
@@ -1744,8 +1718,8 @@ echo -n $list[$i]`)
 
 	out.Reset()
 
-	err = shell.Exec("indexing", `IFS = ("\n")
-seq <= seq 0 2
+	err = shell.Exec("indexing", `tmp <= seq 0 2
+seq <= split($tmp, "\n")
 
 for i in $seq {
     echo -n $list[$i]
@@ -1812,6 +1786,7 @@ setenv SHELL`)
 	shell.SetStdout(&out)
 
 	err = shell.Exec("set env from fn", `fn test() {
+        # test() should no call the setup func in Nash
 }
 
 test()

--- a/internal/sh/split.go
+++ b/internal/sh/split.go
@@ -1,0 +1,174 @@
+package sh
+
+import (
+	"io"
+	"strings"
+
+	"github.com/NeowayLabs/nash/errors"
+	"github.com/NeowayLabs/nash/sh"
+)
+
+type (
+	SplitFn struct {
+		stdin          io.Reader
+		stdout, stderr io.Writer
+
+		done    chan struct{}
+		err     error
+		results sh.Obj
+
+		content string
+		sep     sh.Obj
+	}
+)
+
+func NewSplitFn(env *Shell) *SplitFn {
+	return &SplitFn{
+		stdin:  env.stdin,
+		stdout: env.stdout,
+		stderr: env.stderr,
+	}
+}
+
+func (splitfn *SplitFn) Name() string {
+	return "split"
+}
+
+func (splitfn *SplitFn) ArgNames() []string {
+	return []string{
+		"sep",
+		"content",
+	}
+}
+
+func (splitfn *SplitFn) run() error {
+	var output []string
+
+	content := splitfn.content
+
+	switch splitfn.sep.Type() {
+	case sh.StringType:
+		sep := splitfn.sep.(*sh.StrObj).Str()
+		output = strings.Split(content, sep)
+	case sh.ListType:
+		sepList := splitfn.sep.(*sh.ListObj).List()
+		output = splitByList(content, sepList)
+	case sh.FnType:
+		sepFn := splitfn.sep.(*sh.FnObj).Fn()
+		output = splitByFn(content, sepFn)
+	default:
+		return errors.NewError("Invalid separator value: %v", splitfn.sep)
+	}
+
+	listobjs := make([]sh.Obj, len(output))
+
+	for i := 0; i < len(output); i++ {
+		listobjs[i] = sh.NewStrObj(output[i])
+	}
+
+	splitfn.results = sh.NewListObj(listobjs)
+	return nil
+}
+
+func (splitfn *SplitFn) Start() error {
+	splitfn.done = make(chan struct{})
+
+	go func() {
+		splitfn.err = splitfn.run()
+		splitfn.done <- struct{}{}
+	}()
+
+	return nil
+}
+
+func (splitfn *SplitFn) Wait() error {
+	<-splitfn.done
+	return splitfn.err
+}
+
+func (splitfn *SplitFn) Results() sh.Obj {
+	return splitfn.results
+}
+
+func (splitfn *SplitFn) SetArgs(args []sh.Obj) error {
+	if len(args) != 2 {
+		return errors.NewError("splitfn expects 2 arguments")
+	}
+
+	if args[0].Type() != sh.StringType {
+		return errors.NewError("content must be of type string")
+	}
+
+	content := args[0].(*sh.StrObj)
+
+	splitfn.content = content.Str()
+	splitfn.sep = args[1]
+
+	return nil
+}
+
+func (splitfn *SplitFn) SetEnviron(env []string) {
+	// do nothing
+}
+
+func (splitfn *SplitFn) SetStdin(r io.Reader)  { splitfn.stdin = r }
+func (splitfn *SplitFn) SetStderr(w io.Writer) { splitfn.stderr = w }
+func (splitfn *SplitFn) SetStdout(w io.Writer) { splitfn.stdout = w }
+func (splitfn *SplitFn) StdoutPipe() (io.ReadCloser, error) {
+	return nil, errors.NewError("splitfn doesn't works with pipes")
+}
+func (splitfn *SplitFn) Stdin() io.Reader  { return splitfn.stdin }
+func (splitfn *SplitFn) Stdout() io.Writer { return splitfn.stdout }
+func (splitfn *SplitFn) Stderr() io.Writer { return splitfn.stderr }
+
+func (splitfn *SplitFn) String() string { return "<builtin fn split>" }
+
+func splitByList(content string, delims []sh.Obj) []string {
+	return strings.FieldsFunc(content, func(r rune) bool {
+		for _, delim := range delims {
+			if delim.Type() != sh.StringType {
+				continue
+			}
+
+			objstr := delim.(*sh.StrObj)
+
+			if len(objstr.Str()) > 0 && rune(objstr.Str()[0]) == r {
+				return true
+			}
+		}
+
+		return false
+	})
+}
+
+func splitByFn(content string, splitFunc sh.Fn) []string {
+	return strings.FieldsFunc(content, func(r rune) bool {
+		arg := sh.NewStrObj(string(r))
+		splitFunc.SetArgs([]sh.Obj{arg})
+		err := splitFunc.Start()
+
+		if err != nil {
+			return false
+		}
+
+		err = splitFunc.Wait()
+
+		if err != nil {
+			return false
+		}
+
+		result := splitFunc.Results()
+
+		if result.Type() != sh.StringType {
+			return false
+		}
+
+		status := result.(*sh.StrObj)
+
+		if status.Str() == "0" {
+			return true
+		}
+
+		return false
+	})
+}

--- a/internal/sh/split_test.go
+++ b/internal/sh/split_test.go
@@ -1,0 +1,110 @@
+package sh
+
+import (
+	"testing"
+
+	"github.com/NeowayLabs/nash/sh"
+)
+
+type splitTests struct {
+	expected []sh.Obj
+	content  string
+	sep      sh.Obj
+}
+
+func testSplitTable(t *testing.T, tests []splitTests) {
+	for _, test := range tests {
+		testSplit(t, test.content, test.sep, test.expected)
+	}
+}
+
+func testSplit(t *testing.T, content string, sep sh.Obj, expected []sh.Obj) {
+	shell, err := NewShell()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	splitfn := NewSplitFn(shell)
+	splitfn.SetArgs([]sh.Obj{
+		sh.NewStrObj(content),
+		sep,
+	})
+
+	err = splitfn.Start()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = splitfn.Wait()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := splitfn.Results()
+
+	if result.Type() != sh.ListType {
+		t.Fatalf("Splitfn returns wrong type")
+	}
+
+	values := result.(*sh.ListObj).List()
+
+	if len(values) != len(expected) {
+		t.Fatalf("Expected %d values, but got %d",
+			len(expected), len(values))
+	}
+
+	for i := 0; i < len(values); i++ {
+		if values[i].Type() != sh.StringType {
+			t.Fatalf("Split must return list of strings %v",
+				values[i])
+		}
+
+		v := values[i].(*sh.StrObj).Str()
+		e := expected[i].(*sh.StrObj).Str()
+
+		if v != e {
+			t.Fatalf("Values differ: '%s' != '%s'", e, v)
+		}
+	}
+
+}
+
+func TestSplitFnBasic(t *testing.T) {
+	testSplitTable(t, []splitTests{
+		{
+			content: "some thing",
+			expected: []sh.Obj{
+				sh.NewStrObj("some"),
+				sh.NewStrObj("thing"),
+			},
+			sep: sh.NewStrObj(" "),
+		},
+		{
+			content: "1 2 3 4 5 6 7 8 9 10",
+			expected: []sh.Obj{
+				sh.NewStrObj("1"),
+				sh.NewStrObj("2"),
+				sh.NewStrObj("3"),
+				sh.NewStrObj("4"),
+				sh.NewStrObj("5"),
+				sh.NewStrObj("6"),
+				sh.NewStrObj("7"),
+				sh.NewStrObj("8"),
+				sh.NewStrObj("9"),
+				sh.NewStrObj("10"),
+			},
+			sep: sh.NewStrObj(" "),
+		},
+		{
+			content: "some\nthing",
+			expected: []sh.Obj{
+				sh.NewStrObj("some"),
+				sh.NewStrObj("thing"),
+			},
+			sep: sh.NewStrObj("\n"),
+		},
+	})
+}

--- a/internal/sh/split_test.go
+++ b/internal/sh/split_test.go
@@ -106,5 +106,101 @@ func TestSplitFnBasic(t *testing.T) {
 			},
 			sep: sh.NewStrObj("\n"),
 		},
+		{
+			content: "some thing\nwith\nnew\nlines",
+			expected: []sh.Obj{
+				sh.NewStrObj("some"),
+				sh.NewStrObj("thing"),
+				sh.NewStrObj("with"),
+				sh.NewStrObj("new"),
+				sh.NewStrObj("lines"),
+			},
+			sep: sh.NewListObj([]sh.Obj{
+				sh.NewStrObj(" "),
+				sh.NewStrObj("\n"),
+			}),
+		},
 	})
+}
+
+func TestSplitFnByFunc(t *testing.T) {
+	content := `plan9;linux,osx,windows`
+	expected := []sh.Obj{
+		sh.NewStrObj("plan9"),
+		sh.NewStrObj("linux"),
+		sh.NewStrObj("osx"),
+		sh.NewStrObj("windows"),
+	}
+
+	shell, err := NewShell()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = shell.Exec("TestSplitByFunc", `
+fn tolist(char) {
+        if $char == ";" {
+            return "0"
+        } else if $char == "," {
+            return "0"
+        }
+
+        return "1"
+}`)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fn, ok := shell.GetFn("tolist")
+
+	if !ok {
+		t.Fatalf("Function tolist not declared")
+	}
+
+	splitfn := NewSplitFn(shell)
+	splitfn.SetArgs([]sh.Obj{
+		sh.NewStrObj(content),
+		sh.NewFnObj(fn),
+	})
+
+	err = splitfn.Start()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = splitfn.Wait()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := splitfn.Results()
+
+	if result.Type() != sh.ListType {
+		t.Fatalf("Splitfn returns wrong type")
+	}
+
+	values := result.(*sh.ListObj).List()
+
+	if len(values) != len(expected) {
+		t.Fatalf("Expected %d values, but got %d",
+			len(expected), len(values))
+	}
+
+	for i := 0; i < len(values); i++ {
+		if values[i].Type() != sh.StringType {
+			t.Fatalf("Split must return list of strings %v",
+				values[i])
+		}
+
+		v := values[i].(*sh.StrObj).Str()
+		e := expected[i].(*sh.StrObj).Str()
+
+		if v != e {
+			t.Fatalf("Values differ: '%s' != '%s'", e, v)
+		}
+	}
 }


### PR DESCRIPTION
The `IFS` special variable was removed to increase script reliability. For now, if you want to split variable
content or command output into a list you can use the `split` builtin function.

    content = "some thing"
    list <= split($content, " ")
    echo $list[0] $list[1]

Closes #128 

Signed-off-by: Tiago <tiago.natel@neoway.com.br>