### PR TITLE
Add support for fncall in return

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ matrix:
     - os: osx
 
 language: go
-sudo: required
-
-services:
-  - docker
 
 go:
   - tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
     - os: osx
 
 language: go
+sudo: false
 
 go:
   - tip
@@ -25,9 +26,8 @@ script:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install go ; fi
-  - pip install codecov
 after_success:
-  codecov
+  - bash <(curl -s https://codecov.io/bash)
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ script:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
   - make test
-#  - goveralls -coverprofile=coverage.txt -service=travis-ci
-
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ services:
   - docker
 
 go:
+  - tip
+  - 1.7
   - 1.6
   - 1.5
 install:
@@ -27,7 +29,7 @@ script:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install go ; fi
-  - sudo pip install codecov
+  - pip install codecov
 after_success:
   codecov
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 os:
   - linux
 
+matrix:
+  allow_failures:
+    - os: osx
+
 language: go
 sudo: false
 
@@ -18,9 +22,7 @@ script:
   - go get golang.org/x/tools/cmd/cover
   - make test
 #  - goveralls -coverprofile=coverage.txt -service=travis-ci
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install go ; fi
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 os:
   - linux
-  - osx
-
-matrix:
-  allow_failures:
-    - os: osx
 
 language: go
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os:
   - linux
+  - osx
 
 matrix:
   allow_failures:

--- a/cmd/nash/Makefile
+++ b/cmd/nash/Makefile
@@ -1,7 +1,7 @@
 all: build install
 
 VERSION=$(shell git rev-parse --abbrev-ref HEAD)
-BUILDARGS = -ldflags "-linkmode external -extldflags -static -X main.VersionString=$(VERSION)" -v
+BUILDARGS = -installsuffix netgo -ldflags "-linkmode external -extldflags -static -X main.VersionString=$(VERSION)" -v
 
 build:
 	GO15VENDOREXPERIMENT=1 go build $(BUILDARGS)

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -1086,7 +1086,7 @@ func (p *Parser) parseReturn(retIt scanner.Token) (ast.Node, error) {
 		valueIt.Type() != token.LParen &&
 		valueIt.Type() != token.Ident {
 		return nil, newParserError(valueIt, p.name,
-			"Expected ';', STRING, VARIABLE or LPAREN, but found %v",
+			"Expected ';', STRING, VARIABLE, FUNCALL or LPAREN, but found %v",
 			valueIt)
 	}
 

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -1169,6 +1169,20 @@ func TestParseReturn(t *testing.T) {
 	expected.Root = ln
 
 	parserTestTable("return", `return "value"`, expected, t, true)
+
+	expected = ast.NewTree("return funcall")
+	ln = ast.NewBlockNode(token.NewFileInfo(1, 0))
+
+	ret = ast.NewReturnNode(token.NewFileInfo(1, 0))
+
+	aFn := ast.NewFnInvNode(token.NewFileInfo(1, 7), "a")
+
+	ret.SetReturn(aFn)
+
+	ln.Push(ret)
+	expected.Root = ln
+
+	parserTestTable("return", `return a()`, expected, t, true)
 }
 
 func TestParseIfInvalid(t *testing.T) {

--- a/spec.ebnf
+++ b/spec.ebnf
@@ -51,7 +51,7 @@ fnArgs = { fnArg [ "," ] } .
 fnArg  = identifier .
 
 /* return declaration */
-returnDecl = "return" [ ( variable | string_lit | list ) ] .
+returnDecl = "return" [ ( variable | string_lit | list | fnInv ) ] .
 
 /* Function invocation */
 fnInv = ( variable | identifier ) "(" fnArgValues ")" .


### PR DESCRIPTION
Add the last missing syntax construct for functions:

```sh
fn a() {
    return "1"
}

fn b() {
    return a()
}
```