### PR TITLE
Fixed 'initEnv' for variables with '=' sign

### DIFF
--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -189,14 +189,14 @@ func (shell *Shell) initEnv(processEnv []string) error {
 		var value sh.Obj
 		p := strings.Split(penv, "=")
 
-		if len(p) == 2 {
+		if len(p) >= 2 {
 			// TODO(i4k): handle lists correctly in the future
 			// argv is not special, every list must be handled correctly
 			if p[0] == "argv" {
 				continue
 			}
 
-			value = sh.NewStrObj(p[1])
+			value = sh.NewStrObj(strings.Join(p[1:], "="))
 
 			shell.Setvar(p[0], value)
 			shell.Setenv(p[0], value)

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -107,6 +107,26 @@ func testExec(t *testing.T, desc, execStr, expectedStdout, expectedStderr, expec
 	}
 }
 
+func TestInitEnv(t *testing.T) {
+
+	os.Setenv("TEST", "abc=123=")
+
+	shell, err := NewShell()
+
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	testEnv, _ := shell.Getenv("TEST")
+	expectedTestEnv := "abc=123="
+
+	if testEnv.String() != expectedTestEnv {
+		t.Errorf("Expected TEST Env differs: '%s' != '%s'", testEnv, expectedTestEnv)
+		return
+	}
+}
+
 func TestExecuteFile(t *testing.T) {
 	type fileTests struct {
 		path     string


### PR DESCRIPTION
 - Refactored 'initEnv' to accept '=' signs in environment variable values;
 - Added new test for initEnv.