### PR TITLE
Disable bindfn in non-interactive mode. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ os:
   - linux
   - osx
 
-matrix:
-  allow_failures:
-    - os: osx
-
 language: go
 sudo: false
 

--- a/cmd/nash/Makefile
+++ b/cmd/nash/Makefile
@@ -2,6 +2,10 @@ all: build install
 
 VERSION=$(shell git rev-parse --abbrev-ref HEAD)
 BUILDARGS = -installsuffix netgo -ldflags "-linkmode external -extldflags -static -X main.VersionString=$(VERSION)" -v
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	BUILDARGS = -ldflags "-linkmode external -X main.VersionString=$(VERSION)" -v
+endif
 
 build:
 	GO15VENDOREXPERIMENT=1 go build $(BUILDARGS)

--- a/cmd/nash/main.go
+++ b/cmd/nash/main.go
@@ -41,7 +41,11 @@ func init() {
 }
 
 func main() {
-	var args []string
+	var args  []string
+	var shell *nash.Shell
+	var err   error
+
+	cliMode := false
 
 	flag.Parse()
 
@@ -55,11 +59,18 @@ func main() {
 		file = args[0]
 	}
 
-	shell, err := initShell()
+	if (file == "" && command == "") || interactive {
+		cliMode = true
+		shell, err = initShell()
+	} else {
+		shell, err = nash.New()
+	}
 
 	if err != nil {
 		goto Error
 	}
+
+	shell.SetDebug(debug)
 
 	if addr != "" {
 		startNashd(shell, addr)
@@ -83,7 +94,7 @@ func main() {
 		}
 	}
 
-	if (file == "" && command == "") || interactive {
+	if cliMode {
 		err = cli(shell)
 
 		if err != nil {
@@ -128,8 +139,9 @@ func initShell() (*nash.Shell, error) {
 		return nil, err
 	}
 
-	shell.SetDebug(debug)
-	shell.SetInteractive(interactive)
+	// initShell will run only if the nash command is ran
+	// without arguments or interactive flag, hence interactive mode
+	shell.SetInteractive(true)
 
 	nashpath, err := getnashpath()
 

--- a/cmd/nash/main.go
+++ b/cmd/nash/main.go
@@ -129,6 +129,7 @@ func initShell() (*nash.Shell, error) {
 	}
 
 	shell.SetDebug(debug)
+	shell.SetInteractive(interactive)
 
 	nashpath, err := getnashpath()
 

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -481,9 +481,9 @@ func TestExecuteCd(t *testing.T) {
 	for _, test := range []execTest{
 		{
 			"test cd",
-			`cd /tmp
+			`cd /
         pwd`,
-			"/tmp\n", "", "",
+			"/\n", "", "",
 		},
 		{
 			"test cd",
@@ -497,10 +497,10 @@ func TestExecuteCd(t *testing.T) {
 		{
 			"test cd into $var",
 			`
-        var="/tmp"
+        var="/"
         cd $var
         pwd`,
-			"/tmp\n",
+			"/\n",
 			"",
 			"",
 		},

--- a/nash.go
+++ b/nash.go
@@ -37,6 +37,11 @@ func (nash *Shell) SetDebug(b bool) {
 	nash.interp.SetDebug(b)
 }
 
+// SetInteractive enables interactive (shell) mode.
+func (nash *Shell) SetInteractive(b bool) {
+	nash.interp.SetInteractive(b)
+}
+
 // SetDotDir sets the NASHPATH environment variable. The NASHPATH variable
 // points to the location where nash will lookup for the init script and
 // libraries installed.


### PR DESCRIPTION
This PR got a little too long because In order to fix #62 I had to implement #151 first. Then as discussed in #150 I had to guarantee that `bindfn` would be disabled in non-interactive (script) mode before I could implement the binds precedence over commands.
Fixes #62 .
Closes #151 .
Closes #150 .