### PR TITLE
Add shell.ExecFileArgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ./cmd/cnt/cnt
 /cmd/nash/nash
 /coverage.txt
+cmd/nashfmt/nashfmt

--- a/cmd/nash/main.go
+++ b/cmd/nash/main.go
@@ -41,9 +41,9 @@ func init() {
 }
 
 func main() {
-	var args  []string
+	var args []string
 	var shell *nash.Shell
-	var err   error
+	var err error
 
 	cliMode := false
 
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	if file != "" {
-		err = executeFilename(shell, file, args)
+		err = shell.ExecFileArgs(file, args)
 
 		if err != nil {
 			goto Error
@@ -166,36 +166,4 @@ func initShell() (*nash.Shell, error) {
 	}
 
 	return shell, nil
-}
-
-func executeFilename(shell *nash.Shell, file string, args []string) error {
-	err := shell.ExecuteString("setting args", `ARGS = `+args2Nash(args))
-
-	if err != nil {
-		err = fmt.Errorf("Failed to set nash arguments: %s", err.Error())
-
-		return err
-	}
-
-	err = shell.ExecuteFile(file)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func args2Nash(args []string) string {
-	ret := "("
-
-	for i := 0; i < len(args); i++ {
-		ret += `"` + args[i] + `"`
-
-		if i < (len(args) - 1) {
-			ret += " "
-		}
-	}
-
-	return ret + ")"
 }

--- a/cmd/nash/main.go
+++ b/cmd/nash/main.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	if file != "" {
-		err = shell.ExecFileArgs(file, args)
+		err = shell.ExecFile(file, args...)
 
 		if err != nil {
 			goto Error

--- a/nash.go
+++ b/nash.go
@@ -3,6 +3,7 @@
 package nash
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/NeowayLabs/nash/ast"
@@ -110,6 +111,16 @@ func (nash *Shell) ExecFile(path string) error {
 	return nash.interp.ExecFile(path)
 }
 
+// ExecFileArgs executes the script content of the file specified by path
+// and passes as arguments to the script the given args slice.
+func (nash *Shell) ExecFileArgs(path string, args []string) error {
+	err := nash.ExecuteString("setting args", `ARGS = `+args2Nash(args))
+	if err != nil {
+		return fmt.Errorf("Failed to set nash arguments: %s", err.Error())
+	}
+	return nash.ExecFile(path)
+}
+
 // ExecuteFile executes the given file.
 // Deprecated: Use ExecFile instead.
 func (nash *Shell) ExecuteFile(path string) error {
@@ -155,4 +166,18 @@ func (nash *Shell) Setvar(name string, value sh.Obj) {
 // Getvar retrieves a variable from nash session
 func (nash *Shell) Getvar(name string) (sh.Obj, bool) {
 	return nash.interp.Getvar(name)
+}
+
+func args2Nash(args []string) string {
+	ret := "("
+
+	for i := 0; i < len(args); i++ {
+		ret += `"` + args[i] + `"`
+
+		if i < (len(args) - 1) {
+			ret += " "
+		}
+	}
+
+	return ret + ")"
 }

--- a/nash.go
+++ b/nash.go
@@ -105,20 +105,16 @@ func (nash *Shell) ExecuteString(path, content string) error {
 	return nash.interp.Exec(path, content)
 }
 
-// ExecFile executes the script content of the file specified by path.
-// See Exec for more information.
-func (nash *Shell) ExecFile(path string) error {
-	return nash.interp.ExecFile(path)
-}
-
-// ExecFileArgs executes the script content of the file specified by path
+// ExecFile executes the script content of the file specified by path
 // and passes as arguments to the script the given args slice.
-func (nash *Shell) ExecFileArgs(path string, args []string) error {
-	err := nash.ExecuteString("setting args", `ARGS = `+args2Nash(args))
-	if err != nil {
-		return fmt.Errorf("Failed to set nash arguments: %s", err.Error())
+func (nash *Shell) ExecFile(path string, args ...string) error {
+	if len(args) > 0 {
+		err := nash.ExecuteString("setting args", `ARGS = `+args2Nash(args))
+		if err != nil {
+			return fmt.Errorf("Failed to set nash arguments: %s", err.Error())
+		}
 	}
-	return nash.ExecFile(path)
+	return nash.interp.ExecFile(path)
 }
 
 // ExecuteFile executes the given file.


### PR DESCRIPTION
Not sure if this is a great idea, but I was needing to call nash scripts from Go code, and my scripts take command line args. Checking out the current code I was unable a way to do so, but I found out code on the main package that did it and basically moved it. Probably not on the best way possible. Please advise :-)