### PR TITLE
Update vendor script to not use IFS

### DIFF
--- a/cmd/nash/vendor.sh
+++ b/cmd/nash/vendor.sh
@@ -1,23 +1,30 @@
 #!/usr/bin/env nash
+
 fn vendor() {
-        IFS = ()
-	rm -rf vendor
-	mkdir -p vendor/bin vendor/src vendor/pkg
-	GOPATH <= pwd | xargs echo -n
-	GOPATH = $GOPATH+"/vendor"
-	setenv GOPATH
-	GOBIN = $GOPATH+"/bin"
-	setenv GOBIN
-	go get -v .
-	IFS = ("\n")
-	paths <= ls vendor/src
-	for path in $paths {
-		mv "vendor/src/"+$path vendor/
-	}
-	rm -rf vendor/src vendor/bin vendor/pkg
-	# because nash library is a dependency of cmd/nash
-	# we need to remove it at end
-	rm -rf vendor/github.com/NeowayLabs
+        cwdir <= pwd | xargs echo -n
+        vendordir = $cwdir + "/vendor"
+        rm -rf $vendordir
+
+        bindir = $vendordir + "/bin"
+        srcdir = $vendordir + "/src"
+        pkgdir = $vendordir + "/pkg"
+        mkdir -p $bindir $srcdir $pkgdir
+
+        setenv GOPATH = $vendordir
+        setenv GOBIN = $vendordir
+
+        go get -v .
+
+        rawpaths <= ls $srcdir
+        paths <= split($paths, "\n")
+        for path in $paths {
+                mv $srcdir + $path $vendor
+        }
+        rm -rf $bindir $srcdir $pkgdir
+
+        # because nash library is a dependency of cmd/nash
+        # we need to remove it at end
+        rm -rf vendor/github.com/NeowayLabs
 }
 
 vendor()


### PR DESCRIPTION
@tiago4orion The build is breaking when I run vendor...but it also breaks with the same error if I run the old original script, not sure of what went wrong. The error:

```
github.com/NeowayLabs/nash (download)
github.com/chzyer/readline (download)
github.com/NeowayLabs/nash/token
github.com/NeowayLabs/nash/sh
github.com/chzyer/readline
github.com/NeowayLabs/nash/scanner
github.com/NeowayLabs/nash/ast
github.com/NeowayLabs/nash/errors
github.com/NeowayLabs/nash/parser
github.com/NeowayLabs/nash/internal/sh
github.com/NeowayLabs/nash
_/home/katcipis/workspace/go/src/github.com/NeowayLabs/nash/cmd/nash
# _/home/katcipis/workspace/go/src/github.com/NeowayLabs/nash/cmd/nash
./completer.go:34: c.term.PauseRead undefined (type *readline.Terminal has no field or method PauseRead)
exit status 2
```

The vendor directory does not contain the readline project anymore...even with the old script.