### PR TITLE
fix missing support for list update

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -77,6 +77,7 @@ type (
 		token.FileInfo
 
 		name    string
+		index   Expr
 		val     Expr
 		eqSpace int
 	}
@@ -87,6 +88,7 @@ type (
 		token.FileInfo
 
 		name    string
+		index   Expr
 		cmd     Node
 		eqSpace int
 	}
@@ -515,6 +517,21 @@ func NewAssignmentNode(info token.FileInfo, ident string, value Expr) *Assignmen
 	}
 }
 
+// NewAssignmentIndexNode creates a new assignment for list index
+func NewAssignmentIndexNode(info token.FileInfo, ident string, index Expr, value Expr) *AssignmentNode {
+	return &AssignmentNode{
+		NodeType: NodeAssignment,
+		FileInfo: info,
+		eqSpace:  -1,
+
+		name:  ident,
+		index: index,
+		val:   value,
+	}
+}
+
+func (n *AssignmentNode) Index() Expr { return n.index }
+
 // SetIdentifier sets the name of the variable
 func (n *AssignmentNode) SetIdentifier(a string) {
 	n.name = a
@@ -554,19 +571,19 @@ func (n *AssignmentNode) IsEqual(other Node) bool {
 		return false
 	}
 
-	if n.val == o.val {
-		return true
+	if n.val != nil && o.val != nil && !n.val.IsEqual(o.val) {
+		return false
+	}
+
+	if n.index != nil && o.index != nil && !n.index.IsEqual(o.index) {
+		return false
 	}
 
 	if !cmpInfo(n, other) {
 		return false
 	}
 
-	if n.val != nil {
-		return n.val.IsEqual(o.val)
-	}
-
-	return false
+	return true
 }
 
 // NewExecAssignNode creates a new node for executing something and store the
@@ -584,6 +601,22 @@ func NewExecAssignNode(info token.FileInfo, name string, n Node) (*ExecAssignNod
 		FileInfo: info,
 
 		name:    name,
+		cmd:     n,
+		eqSpace: -1,
+	}, nil
+}
+
+func NewExecAssignIndexNode(info token.FileInfo, name string, index Expr, n Node) (*ExecAssignNode, error) {
+	if !n.Type().IsExecutable() {
+		return nil, errors.New("NewExecAssignNode expects a CommandNode, or PipeNode or FninvNode")
+	}
+
+	return &ExecAssignNode{
+		NodeType: NodeExecAssign,
+		FileInfo: info,
+
+		name:    name,
+		index:   index,
 		cmd:     n,
 		eqSpace: -1,
 	}, nil
@@ -630,18 +663,20 @@ func (n *ExecAssignNode) IsEqual(other Node) bool {
 	}
 
 	if !cmpInfo(n, other) {
+		debug("cmpInfo differs")
 		return false
 	}
 
-	if n.cmd == o.cmd {
-		return true
+	if n.cmd != nil && o.cmd != nil && !n.cmd.IsEqual(o.cmd) {
+		return false
 	}
 
-	if n.cmd != nil {
-		return n.cmd.IsEqual(o.cmd)
+	if n.index != nil && o.index != nil && !n.index.IsEqual(o.index) {
+		return false
+
 	}
 
-	return false
+	return true
 }
 
 // NewCommandNode creates a new node for commands

--- a/ast/node.go
+++ b/ast/node.go
@@ -622,6 +622,8 @@ func NewExecAssignIndexNode(info token.FileInfo, name string, index Expr, n Node
 	}, nil
 }
 
+func (n *ExecAssignNode) Index() Expr { return n.index }
+
 // Name returns the identifier (l-value)
 func (n *ExecAssignNode) Identifier() string {
 	return n.name

--- a/ast/node_fmt.go
+++ b/ast/node_fmt.go
@@ -162,9 +162,16 @@ func (n *AssignmentNode) string() (string, bool) {
 	var (
 		objStr string
 		multi  bool
+		lhs    string
 	)
 
 	obj := n.val
+
+	if n.index != nil {
+		lhs = n.name + "[" + n.index.String() + "]"
+	} else {
+		lhs = n.name
+	}
 
 	if obj.Type().IsExpr() {
 		if obj.Type() == NodeListExpr {
@@ -174,12 +181,12 @@ func (n *AssignmentNode) string() (string, bool) {
 			objStr = obj.String()
 		}
 
-		if n.eqSpace > len(n.name) && !multi {
-			ret := n.name + strings.Repeat(" ", n.eqSpace-len(n.name)) + "= " + objStr
+		if n.eqSpace > len(lhs) && !multi {
+			ret := lhs + strings.Repeat(" ", n.eqSpace-len(lhs)) + "= " + objStr
 			return ret, multi
 		}
 
-		ret := n.name + " = " + objStr
+		ret := lhs + " = " + objStr
 		return ret, multi
 	}
 
@@ -196,7 +203,14 @@ func (n *ExecAssignNode) string() (string, bool) {
 	var (
 		cmdStr string
 		multi  bool
+		lhs    string
 	)
+
+	if n.index != nil {
+		lhs = n.name + "[" + n.index.String() + "]"
+	} else {
+		lhs = n.name
+	}
 
 	if n.cmd.Type() == NodeCommand {
 		cmd := n.cmd.(*CommandNode)
@@ -210,11 +224,11 @@ func (n *ExecAssignNode) string() (string, bool) {
 	}
 
 	if n.eqSpace > len(n.name) {
-		ret := n.name + strings.Repeat(" ", n.eqSpace-len(n.name)) + "<= " + cmdStr
+		ret := lhs + strings.Repeat(" ", n.eqSpace-len(lhs)) + "<= " + cmdStr
 		return ret, multi
 	}
 
-	return n.name + " <= " + cmdStr, multi
+	return lhs + " <= " + cmdStr, multi
 }
 
 // String returns the string representation of command assignment statement

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -193,6 +193,15 @@ kernel 4.7.1`,
 			"",
 			"",
 		},
+		{
+			"list assignment",
+			`l = (0 1 2 3)
+                         l[0] = "666"
+                         echo -n $l`,
+			`666 1 2 3`,
+			"",
+			"",
+		},
 	} {
 		testExec(t,
 			test.desc,

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -202,6 +202,16 @@ kernel 4.7.1`,
 			"",
 			"",
 		},
+		{
+			"list assignment",
+			`l = (0 1 2 3)
+                         a = "2"
+                         l[$a] = "666"
+                         echo -n $l`,
+			`0 1 666 3`,
+			"",
+			"",
+		},
 	} {
 		testExec(t,
 			test.desc,
@@ -240,6 +250,25 @@ func TestExecuteCmdAssignment(t *testing.T) {
 			"",
 			"",
 			"<interactive>:2:25: Invalid assignment from function that does not return values: e()",
+		},
+		{
+			"list assignment",
+			`l = (0 1 2 3)
+                         l[0] <= echo -n 666
+                         echo -n $l`,
+			`666 1 2 3`,
+			"",
+			"",
+		},
+		{
+			"list assignment",
+			`l = (0 1 2 3)
+                         a = "2"
+                         l[$a] <= echo -n "666"
+                         echo -n $l`,
+			`0 1 666 3`,
+			"",
+			"",
 		},
 	} {
 		testExec(t,

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -190,6 +190,25 @@ func TestBasicAssignment(t *testing.T) {
 
 	parserTestTable("test", `test = "hello"+$var`, expected, t, true)
 
+	// test indexed assignment
+
+	ln = ast.NewBlockNode(token.NewFileInfo(1, 0))
+
+	concats = make([]ast.Expr, 2, 2)
+	concats[0] = ast.NewStringExpr(token.NewFileInfo(1, 11), "hello", true)
+	concats[1] = ast.NewVarExpr(token.NewFileInfo(1, 18), "$var")
+
+	arg1 = ast.NewConcatExpr(token.NewFileInfo(1, 11), concats)
+
+	index := ast.NewIntExpr(token.NewFileInfo(1, 5), 0)
+
+	assignIndexed := ast.NewAssignmentIndexNode(token.NewFileInfo(1, 0), "test", index, arg1)
+
+	ln.Push(assignIndexed)
+	expected.Root = ln
+
+	parserTestTable("test", `test[0] = "hello"+$var`, expected, t, true)
+
 	// invalid, requires quote
 	// test=hello
 	parser := NewParser("", `test = hello`)

--- a/scanner/lex.go
+++ b/scanner/lex.go
@@ -358,7 +358,7 @@ func lexStart(l *Lexer) stateFn {
 		if isEndOfLine(next) || isSpace(next) ||
 			next == '=' || next == '(' ||
 			next == ')' || next == ',' ||
-			next == eof {
+			next == '[' || next == eof {
 			lit := scanIdentifier(l)
 
 			if len(lit) > 1 && r >= 'a' && r <= 'z' {

--- a/scanner/lex_test.go
+++ b/scanner/lex_test.go
@@ -218,6 +218,19 @@ func TestLexerSimpleAssignment(t *testing.T) {
 
 	testTable("test concat with parenthesis", `PROMPT = "("+$path+")"+$PROMPT`, expected, t)
 
+	expected = []Token{
+		{typ: token.Ident, val: "a"},
+		{typ: token.LBrack, val: "["},
+		{typ: token.Number, val: "0"},
+		{typ: token.RBrack, val: "]"},
+		{typ: token.Assign, val: "="},
+		{typ: token.String, val: "test"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("test index assignment", `a[0] = "test"`, expected, t)
+
 }
 
 func TestLexerListAssignment(t *testing.T) {


### PR DESCRIPTION
Add missing support to update list entries:

Examples of usage:

```sh
a = (0 1 2 3 4 5)
a[0] = "666"
i = "2"
a[$i] = "666"

# exec commands works also
a[0] <= ls /
a[1] <= echo -n "hello world"
```

Closes #163 

Signed-off-by: Tiago <tiago.natel@neoway.com.br>