### PR TITLE
Advanced for ranges

### DIFF
--- a/ast/node.go
+++ b/ast/node.go
@@ -260,7 +260,7 @@ type (
 		token.FileInfo
 
 		identifier string
-		inVar      string
+		inExpr     Expr
 		tree       *Tree
 	}
 )
@@ -1337,10 +1337,10 @@ func (n *ForNode) SetIdentifier(a string) {
 func (n *ForNode) Identifier() string { return n.identifier }
 
 // InVar return the "in" variable
-func (n *ForNode) InVar() string { return n.inVar }
+func (n *ForNode) InExpr() Expr { return n.inExpr }
 
-// SetInVar set "in" variable
-func (n *ForNode) SetInVar(a string) { n.inVar = a }
+// SetInVar set "in" expression
+func (n *ForNode) SetInExpr(a Expr) { n.inExpr = a }
 
 // SetTree set the for block of statements
 func (n *ForNode) SetTree(a *Tree) {
@@ -1369,8 +1369,19 @@ func (n *ForNode) IsEqual(other Node) bool {
 		return false
 	}
 
-	return n.identifier == o.identifier &&
-		n.inVar == o.inVar
+	if n.identifier != o.identifier {
+		return false
+	}
+
+	if n.inExpr == o.inExpr {
+		return true
+	}
+
+	if n.inExpr == nil || o.inExpr == nil {
+		return false
+	}
+
+	return n.inExpr.IsEqual(o.inExpr)
 }
 
 func cmpInfo(n, other Node) bool {

--- a/ast/node_args.go
+++ b/ast/node_args.go
@@ -125,6 +125,8 @@ func (l *ListExpr) IsEqual(other Node) bool {
 
 	for i := 0; i < len(l.list); i++ {
 		if !l.list[i].IsEqual(o.list[i]) {
+			debug("%v(%s) != %v(%s)", l.list[i], l.list[i].Type(),
+				o.list[i], o.list[i].Type())
 			return false
 		}
 	}

--- a/ast/node_fmt.go
+++ b/ast/node_fmt.go
@@ -623,7 +623,7 @@ func (n *ForNode) String() string {
 	ret := "for"
 
 	if n.identifier != "" {
-		ret += " " + n.identifier + " in " + n.inVar
+		ret += " " + n.identifier + " in " + n.inExpr.String()
 	}
 
 	ret += " {\n"

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -320,6 +320,7 @@ func TestExecuteCmdAssignment(t *testing.T) {
 	}
 }
 
+// IFS *DO NOT* exists anymore. This tests only assure things works as expected (IFS has no power)
 func TestExecuteCmdAssignmentIFS(t *testing.T) {
 	for _, test := range []execTest{
 		{
@@ -331,7 +332,7 @@ for i in $range {
     echo "i = " + $i
 }`,
 			"", "",
-			"<interactive>:4:0: Invalid variable type in for range: StringType",
+			"<interactive>:4:9: Invalid variable type in for range: StringType",
 		},
 		{
 			"ifs",
@@ -342,7 +343,7 @@ for i in $range {
     echo "i = " + $i
 }`,
 			"", "",
-			"<interactive>:4:0: Invalid variable type in for range: StringType",
+			"<interactive>:4:9: Invalid variable type in for range: StringType",
 		},
 		{
 			"ifs",
@@ -353,7 +354,7 @@ for i in $range {
     echo "i = " + $i
 }`,
 			"", "",
-			"<interactive>:4:0: Invalid variable type in for range: StringType",
+			"<interactive>:4:9: Invalid variable type in for range: StringType",
 		},
 		{
 			"ifs",
@@ -364,7 +365,7 @@ for i in $range {
     echo "i = " + $i
 }`,
 			"", "",
-			"<interactive>:4:0: Invalid variable type in for range: StringType",
+			"<interactive>:4:9: Invalid variable type in for range: StringType",
 		},
 	} {
 		testExec(t,
@@ -981,18 +982,18 @@ func TestNonInteractive(t *testing.T) {
 	shell.SetInteractive(false)
 	shell.filename = "<non-interactive>"
 
-	expectedErr := "<non-interactive>:1:0: "+
-		"'hello' is a bind to 'greeting'."+
+	expectedErr := "<non-interactive>:1:0: " +
+		"'hello' is a bind to 'greeting'." +
 		" No binds allowed in non-interactive mode."
 
 	testShellExec(t, shell, "test 'binded' function non-interactive",
 		`hello`, "", "", expectedErr)
 
-	expectedErr = "<non-interactive>:6:8: 'bindfn' is not allowed in"+
+	expectedErr = "<non-interactive>:6:8: 'bindfn' is not allowed in" +
 		" non-interactive mode."
 
 	testShellExec(t, shell, "test bindfn non-interactive",
-	`
+		`
         fn goodbye() {
                 echo "Ciao"
         }

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -1232,11 +1232,21 @@ func TestParseFor(t *testing.T) {
 }`, expected, t, true)
 
 	forStmt.SetIdentifier("f")
-	forStmt.SetInVar("$files")
+	forStmt.SetInExpr(ast.NewVarExpr(token.NewFileInfo(1, 1), "$files"))
 
 	parserTestTable("for", `for f in $files {
 
-}`, expected, t, true)
+		}`, expected, t, true)
+
+	/*		forStmt.SetIdentifier("f")
+			fnInv := ast.NewFnInvNode(token.NewFileInfo(1, 9), "getfiles")
+			fnArg := ast.NewStringExpr(token.NewFileInfo(1, 19), "/", true)
+			fnInv.AddArg(fnArg)
+			forStmt.SetInExpr(fnInv)
+
+			parserTestTable("for", `for f in getfiles("/") {
+
+		}`, expected, t, true)*/
 }
 
 func TestParseVariableIndexing(t *testing.T) {

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -1232,21 +1232,38 @@ func TestParseFor(t *testing.T) {
 }`, expected, t, true)
 
 	forStmt.SetIdentifier("f")
-	forStmt.SetInExpr(ast.NewVarExpr(token.NewFileInfo(1, 1), "$files"))
+	forStmt.SetInExpr(ast.NewVarExpr(token.NewFileInfo(1, 9), "$files"))
 
 	parserTestTable("for", `for f in $files {
 
-		}`, expected, t, true)
+}`, expected, t, true)
 
-	/*		forStmt.SetIdentifier("f")
-			fnInv := ast.NewFnInvNode(token.NewFileInfo(1, 9), "getfiles")
-			fnArg := ast.NewStringExpr(token.NewFileInfo(1, 19), "/", true)
-			fnInv.AddArg(fnArg)
-			forStmt.SetInExpr(fnInv)
+	forStmt.SetIdentifier("f")
+	fnInv := ast.NewFnInvNode(token.NewFileInfo(1, 9), "getfiles")
+	fnArg := ast.NewStringExpr(token.NewFileInfo(1, 19), "/", true)
+	fnInv.AddArg(fnArg)
+	forStmt.SetInExpr(fnInv)
 
-			parserTestTable("for", `for f in getfiles("/") {
+	parserTestTable("for", `for f in getfiles("/") {
 
-		}`, expected, t, true)*/
+}`, expected, t, true)
+
+	forStmt.SetIdentifier("f")
+	value1 := ast.NewStringExpr(token.NewFileInfo(1, 10), "1", false)
+	value2 := ast.NewStringExpr(token.NewFileInfo(1, 12), "2", false)
+	value3 := ast.NewStringExpr(token.NewFileInfo(1, 14), "3", false)
+	value4 := ast.NewStringExpr(token.NewFileInfo(1, 16), "4", false)
+	value5 := ast.NewStringExpr(token.NewFileInfo(1, 18), "5", false)
+
+	list := ast.NewListExpr(token.NewFileInfo(1, 9), []ast.Expr{
+		value1, value2, value3, value4, value5,
+	})
+
+	forStmt.SetInExpr(list)
+
+	parserTestTable("for", `for f in (1 2 3 4 5) {
+
+}`, expected, t, true)
 }
 
 func TestParseVariableIndexing(t *testing.T) {

--- a/scanner/lex_test.go
+++ b/scanner/lex_test.go
@@ -643,6 +643,7 @@ func TestLexerRfork(t *testing.T) {
                 echo "inside namespace :)"
             }
         `, expected, t)
+
 }
 
 func TestLexerSomethingIdontcareanymore(t *testing.T) {
@@ -1458,6 +1459,21 @@ func TestLexerFor(t *testing.T) {
 	}
 
 	testTable("test inf loop", `for f in $files {}`, expected, t)
+
+	expected = []Token{
+		{typ: token.For, val: "for"},
+		{typ: token.Ident, val: "f"},
+		{typ: token.Ident, val: "in"},
+		{typ: token.Ident, val: "getfiles"},
+		{typ: token.LParen, val: "("},
+		{typ: token.String, val: "/"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.LBrace, val: "{"},
+		{typ: token.RBrace, val: "}"},
+		{typ: token.EOF},
+	}
+
+	testTable("test inf loop", `for f in getfiles("/") {}`, expected, t)
 
 }
 

--- a/scanner/lex_test.go
+++ b/scanner/lex_test.go
@@ -1475,6 +1475,23 @@ func TestLexerFor(t *testing.T) {
 
 	testTable("test inf loop", `for f in getfiles("/") {}`, expected, t)
 
+	expected = []Token{
+		{typ: token.For, val: "for"},
+		{typ: token.Ident, val: "f"},
+		{typ: token.Ident, val: "in"},
+		{typ: token.LParen, val: "("},
+		{typ: token.Number, val: "1"},
+		{typ: token.Number, val: "2"},
+		{typ: token.Number, val: "3"},
+		{typ: token.Number, val: "4"},
+		{typ: token.Number, val: "5"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.LBrace, val: "{"},
+		{typ: token.RBrace, val: "}"},
+		{typ: token.EOF},
+	}
+
+	testTable("test inf loop", `for f in (1 2 3 4 5) {}`, expected, t)
 }
 
 func TestLexerFnAsFirstClass(t *testing.T) {


### PR DESCRIPTION
Enables:

```sh
for i in getfiles("/") {

}
```

and 

```sh
for i in (1 2 3 4 5) {

}
```