### PR TITLE
Refactor getCommand to set stuff needed by pipe commands.

### DIFF
--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -989,6 +989,8 @@ func (shell *Shell) executePipe(pipe *ast.PipeNode) (sh.Obj, error) {
 			stdin io.ReadCloser
 		)
 
+		// StdoutPipe complains if Stdout is already set
+		cmd.SetStdout(nil)
 		stdin, err = cmd.StdoutPipe()
 
 		if err != nil {
@@ -1324,6 +1326,7 @@ func (shell *Shell) getCommand(c *ast.CommandNode) (sh.Runner, bool, error) {
 	}
 
 	cmd.SetStdin(shell.stdin)
+	cmd.SetStdout(shell.stdout)
 	cmd.SetStderr(shell.stderr)
 
 	return cmd, ignoreError, nil
@@ -1369,8 +1372,6 @@ func (shell *Shell) executeCommand(c *ast.CommandNode) (sh.Obj, error) {
 	if err != nil {
 		goto cmdError
 	}
-
-	cmd.SetStdout(shell.stdout)
 
 	closeAfterWait, err = shell.setRedirects(cmd, c.Redirects())
 

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -1323,6 +1323,9 @@ func (shell *Shell) getCommand(c *ast.CommandNode) (sh.Runner, bool, error) {
 		return nil, ignoreError, err
 	}
 
+	cmd.SetStdin(shell.stdin)
+	cmd.SetStderr(shell.stderr)
+
 	return cmd, ignoreError, nil
 }
 
@@ -1367,9 +1370,7 @@ func (shell *Shell) executeCommand(c *ast.CommandNode) (sh.Obj, error) {
 		goto cmdError
 	}
 
-	cmd.SetStdin(shell.stdin)
 	cmd.SetStdout(shell.stdout)
-	cmd.SetStderr(shell.stderr)
 
 	closeAfterWait, err = shell.setRedirects(cmd, c.Redirects())
 

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -1182,20 +1182,49 @@ func TestExecuteBindFn(t *testing.T) {
 }
 
 func TestExecutePipe(t *testing.T) {
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
 
-	for _, test := range []execTestCase{
-		{
-			"test pipe",
-			`echo hello | tr -d "[:space:]"`,
-			"hello", "", "",
-		},
-		{
-			"test pipe 3",
-			`echo hello | wc -l | tr -d "[:space:]"`,
-			"1", "", "",
-		},
-	} {
-		testExec(t, test)
+	// Case 1
+	cmd := exec.Command(nashdPath, "-c", `echo hello | tr -d "[:space:]"`)
+
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+
+	expectedOutput := "hello"
+	actualOutput   := string(stdout.Bytes())
+
+	if actualOutput != expectedOutput {
+		t.Errorf("'%s' != '%s'", actualOutput, expectedOutput)
+		return
+	}
+	stdout.Reset()
+	stderr.Reset()
+
+	// Case 2
+	cmd = exec.Command(nashdPath, "-c", `echo hello | wc -l | tr -d "[:space:]"`)
+
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	err = cmd.Run()
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err.Error())
+	}
+
+	expectedOutput = "1"
+	actualOutput   = string(stdout.Bytes())
+
+	if actualOutput != expectedOutput {
+		t.Errorf("'%s' != '%s'", actualOutput, expectedOutput)
+		return
 	}
 }
 


### PR DESCRIPTION
This is kind of shitty for now. But it fixes the problem.
The tests had to be refactored because of race conditions, but I don't know if it's the right solution.
Also, I had to leave the `SetStdout` call in `executeCommand` because `cmd.StdoutPipe()` is already setting Stdout :disappointed:. Any ideas?

Fixes #210 