### PR TITLE
Add support for list literals at function call.

### DIFF
--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -1047,8 +1047,7 @@ path="AAA"
 	got := string(out.Bytes())
 	expected := "1"
 	if got != expected {
-		t.Errorf("String differs: '%s' != '%s'", got, expected)
-		return
+		t.Fatalf("String differs: '%s' != '%s'", got, expected)
 	}
 
 }

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -1032,6 +1032,25 @@ path="AAA"
 		return
 	}
 
+	out.Reset()
+	err = shell.Exec("test fn list arg", `
+	ids_luns = ()
+	id = "1"
+	lun = "lunar"
+	ids_luns <= append($ids_luns, ($id $lun))
+	print(len($ids_luns))`)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	got := string(out.Bytes())
+	expected := "1"
+	if got != expected {
+		t.Errorf("String differs: '%s' != '%s'", got, expected)
+		return
+	}
+
 }
 
 func TestFnComposition(t *testing.T) {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -1143,15 +1143,21 @@ func (p *Parser) parseFnInv(ident scanner.Token, allowSemicolon bool) (ast.Node,
 			} else {
 				goto parseError
 			}
-		} else {
-			goto parseError
 		}
 
-		if p.peek().Type() == token.Comma {
+		it = p.peek()
+		if it.Type() == token.Comma {
 			p.ignore()
 
 			continue
 		}
+
+		if it.Type() == token.RParen {
+			p.next()
+			break
+		}
+
+		goto parseError
 	}
 
 	// semicolon is optional here

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -1104,7 +1104,6 @@ func (p *Parser) parseFnInv(ident scanner.Token, allowSemicolon bool) (ast.Node,
 	n := ast.NewFnInvNode(ident.FileInfo, ident.Value())
 
 	it := p.next()
-
 	if it.Type() != token.LParen {
 		return nil, newParserError(it, p.name, "Invalid token %v. Expected '('", it)
 	}
@@ -1120,6 +1119,12 @@ func (p *Parser) parseFnInv(ident scanner.Token, allowSemicolon bool) (ast.Node,
 			}
 
 			n.AddArg(arg)
+		} else if it.Type() == token.LParen {
+			listArg, err := p.parseList(nil)
+			if err != nil {
+				return nil, err
+			}
+			n.AddArg(listArg)
 		} else if it.Type() == token.RParen {
 			p.next()
 			break
@@ -1130,7 +1135,6 @@ func (p *Parser) parseFnInv(ident scanner.Token, allowSemicolon bool) (ast.Node,
 
 			if it.Type() == token.LParen {
 				arg, err := p.parseFnInv(ident, false)
-
 				if err != nil {
 					return nil, err
 				}
@@ -1285,33 +1289,10 @@ func (p *Parser) parseReturn(retTok scanner.Token) (ast.Node, error) {
 		}
 
 		if tok.Type() == token.LParen {
-			listInfo := tok.FileInfo
-			p.ignore()
-
-			var values []ast.Expr
-
-			for tok = p.peek(); tok.Type() != token.RParen; tok = p.peek() {
-				if tok.Type() == token.EOF {
-					// list unfinished
-					break
-				}
-
-				arg, err := p.getArgument(true, true)
-
-				if err != nil {
-					return nil, err
-				}
-
-				values = append(values, arg)
+			listArg, err := p.parseList(nil)
+			if err != nil {
+				return nil, err
 			}
-
-			if tok.Type() != token.RParen {
-				return nil, errors.NewUnfinishedListError(p.name, tok)
-			}
-
-			p.ignore()
-
-			listArg := ast.NewListExpr(listInfo, values)
 			returnExprs = append(returnExprs, listArg)
 		} else if tok.Type() == token.Ident {
 			p.next()

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -865,7 +865,7 @@ func TestParseIf(t *testing.T) {
 }`, expected, t, true)
 }
 
-func TestParseFnInv(t *testing.T) {
+func TestParseFuncall(t *testing.T) {
 	expected := ast.NewTree("fn inv")
 	ln := ast.NewBlockNode(token.NewFileInfo(1, 0))
 	aFn := ast.NewFnInvNode(token.NewFileInfo(1, 0), "a")
@@ -907,6 +907,19 @@ func TestParseFnInv(t *testing.T) {
 	expected.Root = ln
 
 	parserTest("test fn composition", `a(b(b()))`, expected, t, true)
+
+	expected = ast.NewTree("fn inv list")
+	ln = ast.NewBlockNode(token.NewFileInfo(1, 0))
+	aFn = ast.NewFnInvNode(token.NewFileInfo(1, 0), "a")
+	lExpr := ast.NewListExpr(token.NewFileInfo(1, 2), []ast.Expr{
+		ast.NewStringExpr(token.NewFileInfo(1, 4), "1", true),
+		ast.NewStringExpr(token.NewFileInfo(1, 8), "2", true),
+		ast.NewStringExpr(token.NewFileInfo(1, 12), "3", true),
+	})
+	aFn.AddArg(lExpr)
+	ln.Push(aFn)
+	expected.Root = ln
+	parserTest("test fn list arg", `a(("1" "2" "3"))`, expected, t, true)
 }
 
 func TestParseIfFnInv(t *testing.T) {

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -947,8 +947,7 @@ func TestParseFuncall(t *testing.T) {
 		parser := NewParser("test", tc)
 		_, err := parser.Parse()
 		if err != nil {
-			t.Error(err)
-			return
+			t.Fatal(err)
 		}
 	}
 }
@@ -967,8 +966,7 @@ func TestParseFuncallInvalid(t *testing.T) {
 		parser := NewParser("test", tc)
 		_, err := parser.Parse()
 		if err == nil {
-			t.Errorf("Syntax '%s' must fail...", tc)
-			return
+			t.Fatalf("Syntax '%s' must fail...", tc)
 		}
 	}
 }

--- a/scanner/lex_test.go
+++ b/scanner/lex_test.go
@@ -1178,7 +1178,7 @@ func TestLexerFnBasic(t *testing.T) {
 }`, expected, t)
 }
 
-func TestLexerFnInvocation(t *testing.T) {
+func TestLexerFuncall(t *testing.T) {
 	expected := []Token{
 		{typ: token.Ident, val: "build"},
 		{typ: token.LParen, val: "("},
@@ -1238,6 +1238,25 @@ func TestLexerFnInvocation(t *testing.T) {
 	}
 
 	testTable("test fn composition", `a(b())`, expected, t)
+
+	expected = []Token{
+		{typ: token.Ident, val: "ids_luns"},
+		{typ: token.AssignCmd, val: "<="},
+		{typ: token.Ident, val: "append"},
+		{typ: token.LParen, val: "("},
+		{typ: token.Variable, val: "$ids_luns"},
+		{typ: token.Comma, val: ","},
+		{typ: token.LParen, val: "("},
+		{typ: token.Variable, val: "$id"},
+		{typ: token.Variable, val: "$lun"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("test katcipis bad mood", `ids_luns <= append($ids_luns, ($id $lun))`,
+		expected, t)
 }
 
 func TestLexerAssignCmdOut(t *testing.T) {

--- a/spec.ebnf
+++ b/spec.ebnf
@@ -59,7 +59,7 @@ returnDecl = "return" [ ( variable | stringLit | list | fnInv ) ] .
 fnInv = ( variable | identifier ) "(" fnArgValues ")" .
 
 fnArgValues = { fnArgValue [ "," ] } .
-fnArgValue  = [ stringLit | stringConcat | variable | fnInv ] .
+fnArgValue  = [ stringLit | stringConcat | list | variable | fnInv ] .
 
 /* Function binding */
 bindfn = "bindfn" identifier identifier .


### PR DESCRIPTION
The code below now is valid:

  ids_luns <= append($ids_luns, ($id $lun))

Closes #214 

Signed-off-by: Tiago Natel de Moura <tiago.natel@neoway.com.br>