### PR TITLE
Add support for variadic arguments

### DIFF
--- a/ast/node_args.go
+++ b/ast/node_args.go
@@ -84,7 +84,11 @@ func (i *IntExpr) IsEqual(other Node) bool {
 	return i.val == o.val
 }
 
-func NewListExpr(info token.FileInfo, values []Expr, variadic bool) *ListExpr {
+func NewListExpr(info token.FileInfo, values []Expr) *ListExpr {
+	return NewListVariadicExpr(info, values, false)
+}
+
+func NewListVariadicExpr(info token.FileInfo, values []Expr, variadic bool) *ListExpr {
 	return &ListExpr{
 		NodeType: NodeListExpr,
 		FileInfo: info,
@@ -171,10 +175,15 @@ func (c *ConcatExpr) IsEqual(other Node) bool {
 }
 
 func NewVarExpr(info token.FileInfo, name string) *VarExpr {
+	return NewVarVariadicExpr(info, name, false)
+}
+
+func NewVarVariadicExpr(info token.FileInfo, name string, isVariadic bool) *VarExpr {
 	return &VarExpr{
-		NodeType: NodeVarExpr,
-		FileInfo: info,
-		Name:     name,
+		NodeType:   NodeVarExpr,
+		FileInfo:   info,
+		Name:       name,
+		IsVariadic: isVariadic,
 	}
 }
 
@@ -192,7 +201,11 @@ func (v *VarExpr) IsEqual(other Node) bool {
 		v.IsVariadic == o.IsVariadic
 }
 
-func NewIndexExpr(info token.FileInfo, va *VarExpr, idx Expr, variadic bool) *IndexExpr {
+func NewIndexExpr(info token.FileInfo, va *VarExpr, idx Expr) *IndexExpr {
+	return NewIndexVariadicExpr(info, va, idx, false)
+}
+
+func NewIndexVariadicExpr(info token.FileInfo, va *VarExpr, idx Expr, variadic bool) *IndexExpr {
 	return &IndexExpr{
 		NodeType: NodeIndexExpr,
 		FileInfo: info,

--- a/ast/node_args.go
+++ b/ast/node_args.go
@@ -118,10 +118,11 @@ func (l *ListExpr) IsEqual(other Node) bool {
 		return false
 	}
 
-	for i := 0; i < len(l.List); i++ {
-		if !l.List[i].IsEqual(o.List[i]) {
-			debug("%v(%s) != %v(%s)", l.List[i], l.List[i].Type(),
-				o.List[i], o.List[i].Type())
+	for i, val := range l.List {
+		oval := o.List[i]
+		if !val.IsEqual(oval) {
+			debug("%v(%s) != %v(%s)", val, val.Type(),
+				oval, oval.Type())
 			return false
 		}
 	}

--- a/ast/node_args.go
+++ b/ast/node_args.go
@@ -84,20 +84,19 @@ func (i *IntExpr) IsEqual(other Node) bool {
 	return i.val == o.val
 }
 
-func NewListExpr(info token.FileInfo, values []Expr) *ListExpr {
+func NewListExpr(info token.FileInfo, values []Expr, variadic bool) *ListExpr {
 	return &ListExpr{
 		NodeType: NodeListExpr,
 		FileInfo: info,
 
-		list: values,
+		List:       values,
+		IsVariadic: variadic,
 	}
 }
 
-func (l *ListExpr) List() []Expr { return l.list }
-
 // PushExpr push an expression to end of the list
 func (l *ListExpr) PushExpr(a Expr) {
-	l.list = append(l.list, a)
+	l.List = append(l.List, a)
 }
 
 func (l *ListExpr) IsEqual(other Node) bool {
@@ -111,14 +110,14 @@ func (l *ListExpr) IsEqual(other Node) bool {
 		return false
 	}
 
-	if len(l.list) != len(o.list) {
+	if len(l.List) != len(o.List) {
 		return false
 	}
 
-	for i := 0; i < len(l.list); i++ {
-		if !l.list[i].IsEqual(o.list[i]) {
-			debug("%v(%s) != %v(%s)", l.list[i], l.list[i].Type(),
-				o.list[i], o.list[i].Type())
+	for i := 0; i < len(l.List); i++ {
+		if !l.List[i].IsEqual(o.List[i]) {
+			debug("%v(%s) != %v(%s)", l.List[i], l.List[i].Type(),
+				o.List[i], o.List[i].Type())
 			return false
 		}
 	}
@@ -175,11 +174,9 @@ func NewVarExpr(info token.FileInfo, name string) *VarExpr {
 	return &VarExpr{
 		NodeType: NodeVarExpr,
 		FileInfo: info,
-		name:     name,
+		Name:     name,
 	}
 }
-
-func (v *VarExpr) Name() string { return v.name }
 
 func (v *VarExpr) IsEqual(other Node) bool {
 	if !v.equal(v, other) {
@@ -187,26 +184,24 @@ func (v *VarExpr) IsEqual(other Node) bool {
 	}
 
 	o, ok := other.(*VarExpr)
-
 	if !ok {
 		return false
 	}
 
-	return v.name == o.name
+	return v.Name == o.Name &&
+		v.IsVariadic == o.IsVariadic
 }
 
-func NewIndexExpr(info token.FileInfo, variable *VarExpr, index Expr) *IndexExpr {
+func NewIndexExpr(info token.FileInfo, va *VarExpr, idx Expr, variadic bool) *IndexExpr {
 	return &IndexExpr{
 		NodeType: NodeIndexExpr,
 		FileInfo: info,
 
-		variable: variable,
-		index:    index,
+		Var:        va,
+		Index:      idx,
+		IsVariadic: variadic,
 	}
 }
-
-func (i *IndexExpr) Var() *VarExpr { return i.variable }
-func (i *IndexExpr) Index() Expr   { return i.index }
 
 func (i *IndexExpr) IsEqual(other Node) bool {
 	if !i.equal(i, other) {
@@ -214,10 +209,11 @@ func (i *IndexExpr) IsEqual(other Node) bool {
 	}
 
 	o, ok := other.(*IndexExpr)
-
 	if !ok {
 		return false
 	}
 
-	return i.variable.IsEqual(o.variable) && i.index.IsEqual(o.index)
+	return i.Var.IsEqual(o.Var) &&
+		i.Index.IsEqual(o.Index) &&
+		i.IsVariadic == o.IsVariadic
 }

--- a/ast/node_fmt.go
+++ b/ast/node_fmt.go
@@ -18,16 +18,16 @@ func (i *IntExpr) String() string {
 }
 
 func (l *ListExpr) string() (string, bool) {
-	elems := make([]string, len(l.list))
+	elems := make([]string, len(l.List))
 	columnCount := 0
 	forceMulti := false
 
-	for i := 0; i < len(l.list); i++ {
-		if l.list[i].Type() == NodeListExpr {
+	for i := 0; i < len(l.List); i++ {
+		if l.List[i].Type() == NodeListExpr {
 			forceMulti = true
 		}
 
-		elems[i] = l.list[i].String()
+		elems[i] = l.List[i].String()
 		columnCount += len(elems[i])
 	}
 
@@ -59,11 +59,18 @@ func (c *ConcatExpr) String() string {
 }
 
 func (v *VarExpr) String() string {
-	return v.name
+	if v.IsVariadic {
+		return v.Name + "..."
+	}
+	return v.Name
 }
 
 func (i *IndexExpr) String() string {
-	return i.variable.String() + "[" + i.index.String() + "]"
+	ret := i.Var.String() + "[" + i.Index.String() + "]"
+	if i.IsVariadic {
+		return ret + "..."
+	}
+	return ret
 }
 
 func (l *BlockNode) adjustGroupAssign(node assignable, nodes []Node) {
@@ -564,8 +571,7 @@ func (n *FnDeclNode) String() string {
 	}
 
 	for i := 0; i < len(n.args); i++ {
-		fnStr += n.args[i]
-
+		fnStr += n.args[i].String()
 		if i < (len(n.args) - 1) {
 			fnStr += ", "
 		}

--- a/ast/node_fmt.go
+++ b/ast/node_fmt.go
@@ -596,6 +596,14 @@ func (n *FnDeclNode) String() string {
 	return fnStr
 }
 
+func (arg *FnArgNode) String() string {
+	ret := arg.Name
+	if arg.IsVariadic {
+		ret += "..."
+	}
+	return ret
+}
+
 // String returns the string representation of function invocation
 func (n *FnInvNode) string() (string, bool) {
 	fnInvStr := n.name + "("

--- a/ast/node_fmt.go
+++ b/ast/node_fmt.go
@@ -1,6 +1,7 @@
 package ast
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -66,7 +67,7 @@ func (v *VarExpr) String() string {
 }
 
 func (i *IndexExpr) String() string {
-	ret := i.Var.String() + "[" + i.Index.String() + "]"
+	ret := fmt.Sprintf("%s[%s]", i.Var, i.Index)
 	if i.IsVariadic {
 		return ret + "..."
 	}

--- a/ast/nodetype_string.go
+++ b/ast/nodetype_string.go
@@ -4,9 +4,9 @@ package ast
 
 import "fmt"
 
-const _NodeType_name = "NodeSetenvNodeBlockNodeNameNodeAssignmentNodeExecAssignNodeImportexecBeginNodeCommandNodePipeNodeRedirectNodeFnInvexecEndexpressionBeginNodeStringExprNodeIntExprNodeVarExprNodeListExprNodeIndexExprNodeConcatExprexpressionEndNodeStringNodeRforkNodeRforkFlagsNodeIfNodeCommentNodeFnDeclNodeReturnNodeBindFnNodeDumpNodeFor"
+const _NodeType_name = "NodeSetenvNodeBlockNodeNameNodeAssignNodeExecAssignNodeImportexecBeginNodeCommandNodePipeNodeRedirectNodeFnInvexecEndexpressionBeginNodeStringExprNodeIntExprNodeVarExprNodeListExprNodeIndexExprNodeConcatExprexpressionEndNodeStringNodeRforkNodeRforkFlagsNodeIfNodeCommentNodeFnArgNodeFnDeclNodeReturnNodeBindFnNodeDumpNodeFor"
 
-var _NodeType_index = [...]uint16{0, 10, 19, 27, 41, 55, 65, 74, 85, 93, 105, 114, 121, 136, 150, 161, 172, 184, 197, 211, 224, 234, 243, 257, 263, 274, 284, 294, 304, 312, 319}
+var _NodeType_index = [...]uint16{0, 10, 19, 27, 37, 51, 61, 70, 81, 89, 101, 110, 117, 132, 146, 157, 168, 180, 193, 207, 220, 230, 239, 253, 259, 270, 279, 289, 299, 309, 317, 324}
 
 func (i NodeType) String() string {
 	i -= 1

--- a/internal/sh/builtin.go
+++ b/internal/sh/builtin.go
@@ -48,7 +48,7 @@ func (f *builtinFn) Name() string {
 	return f.name
 }
 
-func (f *builtinFn) ArgNames() []string {
+func (f *builtinFn) ArgNames() []sh.FnArg {
 	return f.fn.ArgNames()
 }
 

--- a/internal/sh/builtin/append.go
+++ b/internal/sh/builtin/append.go
@@ -32,12 +32,12 @@ func (appendfn *appendFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.
 
 func (appendfn *appendFn) SetArgs(args []sh.Obj) error {
 	if len(args) < 2 {
-		return errors.NewError("appendfn expects at least two arguments")
+		return errors.NewError("append expects at least two arguments")
 	}
 
 	obj := args[0]
 	if obj.Type() != sh.ListType {
-		return errors.NewError("appendfn expects a list as first argument, but a %s was provided",
+		return errors.NewError("append expects a list as first argument, but a %s was provided",
 			obj.Type())
 	}
 

--- a/internal/sh/builtin/append.go
+++ b/internal/sh/builtin/append.go
@@ -37,7 +37,8 @@ func (appendfn *appendFn) SetArgs(args []sh.Obj) error {
 
 	obj := args[0]
 	if obj.Type() != sh.ListType {
-		return errors.NewError("appendfn expects a list as first argument, but a %s[%s] was provided", obj, obj.Type())
+		return errors.NewError("appendfn expects a list as first argument, but a %s was provided",
+			obj.Type())
 	}
 
 	values := args[1:]

--- a/internal/sh/builtin/append_test.go
+++ b/internal/sh/builtin/append_test.go
@@ -52,14 +52,14 @@ func testAppend(t *testing.T, tc testcase) {
 func TestAppend(t *testing.T) {
 	for _, tc := range []testcase{
 		{
-			name:        "at least two arguments",
+			name:        "no argument fails",
 			code:        `append()`,
-			expectedErr: "<interactive>:1:0: appendfn expects at least two arguments",
+			expectedErr: "<interactive>:1:0: append expects at least two arguments",
 		},
 		{
-			name:        "at least two arguments",
+			name:        "one argument fails",
 			code:        `append("1")`,
-			expectedErr: "<interactive>:1:0: appendfn expects at least two arguments",
+			expectedErr: "<interactive>:1:0: append expects at least two arguments",
 		},
 		{
 			name: "simple append",
@@ -76,7 +76,7 @@ func TestAppend(t *testing.T) {
 			code: `a = "something"
 		 a <= append($a, "other")
 		 echo -n $a...`,
-			expectedErr: "<interactive>:2:8: appendfn expects a " +
+			expectedErr: "<interactive>:2:8: append expects a " +
 				"list as first argument, but a StringType was provided",
 			expectedStdout: "",
 			expectedStderr: "",

--- a/internal/sh/builtin/append_test.go
+++ b/internal/sh/builtin/append_test.go
@@ -7,45 +7,106 @@ import (
 	"github.com/NeowayLabs/nash/internal/sh"
 )
 
-func TestAppend(t *testing.T) {
-	sh, err := sh.NewShell()
+type testcase struct {
+	name           string
+	code           string
+	expectedErr    string
+	expectedStdout string
+	expectedStderr string
+}
 
+func testAppend(t *testing.T, tc testcase) {
+	sh, err := sh.NewShell()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
+	}
+
+	var (
+		outb, errb bytes.Buffer
+	)
+	sh.SetStdout(&outb)
+	sh.SetStderr(&errb)
+
+	err = sh.Exec(tc.name, tc.code)
+	stdout := string(outb.Bytes())
+	stderr := errb.String()
+
+	if stdout != tc.expectedStdout {
+		t.Errorf("String differs: '%s' != '%s'", tc.expectedStdout, stdout)
+		return
+	}
+	if stderr != tc.expectedStderr {
+		t.Errorf("String differs: '%s' != '%s'", tc.expectedStderr, stderr)
 		return
 	}
 
-	var out bytes.Buffer
+	if err != nil {
+		if err.Error() != tc.expectedErr {
+			t.Fatalf("Expected err '%s' but got '%s'", tc.expectedErr, err.Error())
+		}
+	} else if tc.expectedErr != "" {
+		t.Fatalf("Expected err '%s' but err is nil", tc.expectedErr)
+	}
+}
 
-	sh.SetStdout(&out)
-
-	err = sh.Exec(
-		"test append",
-		`a = ()
+func TestAppend(t *testing.T) {
+	for _, tc := range []testcase{
+		{
+			name:        "at least two arguments",
+			code:        `append()`,
+			expectedErr: "<interactive>:1:0: appendfn expects at least two arguments",
+		},
+		{
+			name:        "at least two arguments",
+			code:        `append("1")`,
+			expectedErr: "<interactive>:1:0: appendfn expects at least two arguments",
+		},
+		{
+			name: "simple append",
+			code: `a = ()
 		 a <= append($a, "hello")
 		 a <= append($a, "world")
-		 echo -n $a`,
-	)
-
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	if "hello world" != string(out.Bytes()) {
-		t.Errorf("String differs: '%s' != '%s'", "hello world", string(out.Bytes()))
-		return
-	}
-
-	err = sh.Exec(
-		"test append fail",
-		`a = "something"
+		 echo -n $a...`,
+			expectedErr:    "",
+			expectedStdout: "hello world",
+			expectedStderr: "",
+		},
+		{
+			name: "append is for lists",
+			code: `a = "something"
 		 a <= append($a, "other")
-		 echo -n $a`,
-	)
-
-	if err == nil {
-		t.Errorf("Must fail... Append only should works with lists")
-		return
+		 echo -n $a...`,
+			expectedErr: "<interactive>:2:8: appendfn expects a " +
+				"list as first argument, but a StringType was provided",
+			expectedStdout: "",
+			expectedStderr: "",
+		},
+		{
+			name: "var args",
+			code: `a <= append((), "1", "2", "3", "4", "5", "6")
+				echo -n $a...`,
+			expectedErr:    "",
+			expectedStdout: "1 2 3 4 5 6",
+			expectedStderr: "",
+		},
+		{
+			name: "append of lists",
+			code: `a <= append((), (), ())
+				if len($a) != "2" {
+					print("wrong")
+				} else if len($a[0]) != "0" {
+					print("wrong")
+				} else if len($a[1]) != "0" {
+					print("wrong")
+				} else { print("ok") }`,
+			expectedErr:    "",
+			expectedStdout: "ok",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			testAppend(t, tc)
+		})
 	}
+
 }

--- a/internal/sh/builtin/chdir.go
+++ b/internal/sh/builtin/chdir.go
@@ -18,8 +18,10 @@ func newChdir() *chdirFn {
 	return &chdirFn{}
 }
 
-func (chdir *chdirFn) ArgNames() []string {
-	return []string{"dir"}
+func (chdir *chdirFn) ArgNames() []sh.FnArg {
+	return []sh.FnArg{
+		sh.NewFnArg("dir", false),
+	}
 }
 
 func (chdir *chdirFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj, error) {
@@ -28,11 +30,10 @@ func (chdir *chdirFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj,
 
 func (chdir *chdirFn) SetArgs(args []sh.Obj) error {
 	if len(args) != 1 {
-		return errors.NewError("chdir expects one argument")
+		return errors.NewError("chdir expects one argument, but received %q", args)
 	}
 
 	obj := args[0]
-
 	if obj.Type() != sh.StringType {
 		return errors.NewError("chdir expects a string, but a %s was provided", obj.Type())
 	}

--- a/internal/sh/builtin/exit.go
+++ b/internal/sh/builtin/exit.go
@@ -19,8 +19,10 @@ func newExit() *exitFn {
 	return &exitFn{}
 }
 
-func (e *exitFn) ArgNames() []string {
-	return []string{"status"}
+func (e *exitFn) ArgNames() []sh.FnArg {
+	return []sh.FnArg{
+		sh.NewFnArg("status", false),
+	}
 }
 
 func (e *exitFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj, error) {
@@ -30,7 +32,7 @@ func (e *exitFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj, erro
 
 func (e *exitFn) SetArgs(args []sh.Obj) error {
 	if len(args) != 1 {
-		return errors.NewError("exit expects one argument")
+		return errors.NewError("exit expects 1 argument")
 	}
 
 	obj := args[0]

--- a/internal/sh/builtin/format.go
+++ b/internal/sh/builtin/format.go
@@ -19,8 +19,11 @@ func newFormat() *formatFn {
 	return &formatFn{}
 }
 
-func (f *formatFn) ArgNames() []string {
-	return []string{"fmt", "args..."}
+func (f *formatFn) ArgNames() []sh.FnArg {
+	return []sh.FnArg{
+		sh.NewFnArg("fmt", false),
+		sh.NewFnArg("arg...", true),
+	}
 }
 
 func (f *formatFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj, error) {

--- a/internal/sh/builtin/glob.go
+++ b/internal/sh/builtin/glob.go
@@ -18,8 +18,8 @@ func newGlob() *globFn {
 	return &globFn{}
 }
 
-func (p *globFn) ArgNames() []string {
-	return []string{"pattern"}
+func (p *globFn) ArgNames() []sh.FnArg {
+	return []sh.FnArg{sh.NewFnArg("pattern", false)}
 }
 
 func (g *globFn) Run(in io.Reader, out io.Writer, e io.Writer) ([]sh.Obj, error) {
@@ -35,7 +35,7 @@ func (g *globFn) Run(in io.Reader, out io.Writer, e io.Writer) ([]sh.Obj, error)
 }
 
 func (g *globFn) SetArgs(args []sh.Obj) error {
-	if len(args) == 0 {
+	if len(args) != 1 {
 		return errors.NewError("glob expects 1 string argument (the pattern)")
 	}
 

--- a/internal/sh/builtin/len.go
+++ b/internal/sh/builtin/len.go
@@ -18,8 +18,10 @@ func newLen() *lenFn {
 	return &lenFn{}
 }
 
-func (l *lenFn) ArgNames() []string {
-	return []string{"list"}
+func (l *lenFn) ArgNames() []sh.FnArg {
+	return []sh.FnArg{
+		sh.NewFnArg("list", false),
+	}
 }
 
 func lenresult(res int) []sh.Obj {

--- a/internal/sh/builtin/loader.go
+++ b/internal/sh/builtin/loader.go
@@ -9,7 +9,7 @@ import (
 // Fn is the contract of a built in function, that is simpler
 // than the core nash Fn.
 type Fn interface {
-	ArgNames() []string
+	ArgNames() []sh.FnArg
 	SetArgs(args []sh.Obj) error
 	Run(
 		stdin io.Reader,

--- a/internal/sh/builtin/print.go
+++ b/internal/sh/builtin/print.go
@@ -19,8 +19,11 @@ func newPrint() *printFn {
 	return &printFn{}
 }
 
-func (p *printFn) ArgNames() []string {
-	return []string{"fmt", "args..."}
+func (p *printFn) ArgNames() []sh.FnArg {
+	return []sh.FnArg{
+		sh.NewFnArg("fmt", false),
+		sh.NewFnArg("arg...", true),
+	}
 }
 
 func (p *printFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj, error) {

--- a/internal/sh/builtin/split.go
+++ b/internal/sh/builtin/split.go
@@ -53,11 +53,11 @@ func (s *splitFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj, err
 
 func (s *splitFn) SetArgs(args []sh.Obj) error {
 	if len(args) != 2 {
-		return errors.NewError("splitfn expects 2 arguments")
+		return errors.NewError("split: expects 2 parameters")
 	}
 
 	if args[0].Type() != sh.StringType {
-		return errors.NewError("content must be of type string")
+		return errors.NewError("split: first parameter must be a string")
 	}
 
 	content := args[0].(*sh.StrObj)

--- a/internal/sh/builtin/split.go
+++ b/internal/sh/builtin/split.go
@@ -19,8 +19,11 @@ func newSplit() *splitFn {
 	return &splitFn{}
 }
 
-func (s *splitFn) ArgNames() []string {
-	return []string{"sep", "content"}
+func (s *splitFn) ArgNames() []sh.FnArg {
+	return []sh.FnArg{
+		sh.NewFnArg("sep", false),
+		sh.NewFnArg("content", false),
+	}
 }
 
 func (s *splitFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj, error) {
@@ -43,7 +46,6 @@ func (s *splitFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj, err
 	}
 
 	listobjs := make([]sh.Obj, len(output))
-
 	for i := 0; i < len(output); i++ {
 		listobjs[i] = sh.NewStrObj(output[i])
 	}
@@ -61,10 +63,8 @@ func (s *splitFn) SetArgs(args []sh.Obj) error {
 	}
 
 	content := args[0].(*sh.StrObj)
-
 	s.content = content.Str()
 	s.sep = args[1]
-
 	return nil
 }
 

--- a/internal/sh/cmd.go
+++ b/internal/sh/cmd.go
@@ -126,20 +126,3 @@ func (c *Cmd) Start() error {
 }
 
 func (c *Cmd) Results() []sh.Obj { return nil }
-
-func cmdArgs(nodeArgs []ast.Expr, envShell *Shell) ([]sh.Obj, error) {
-	args := make([]sh.Obj, 0, len(nodeArgs))
-
-	for i := 0; i < len(nodeArgs); i++ {
-		carg := nodeArgs[i]
-
-		objs, err := envShell.evalExpr(carg)
-		if err != nil {
-			return nil, err
-		}
-
-		args = append(args, objs)
-	}
-
-	return args, nil
-}

--- a/internal/sh/cmd.go
+++ b/internal/sh/cmd.go
@@ -133,14 +133,12 @@ func cmdArgs(nodeArgs []ast.Expr, envShell *Shell) ([]sh.Obj, error) {
 	for i := 0; i < len(nodeArgs); i++ {
 		carg := nodeArgs[i]
 
-		obj, err := envShell.evalExpr(carg)
-
+		objs, err := envShell.evalExpr(carg)
 		if err != nil {
 			return nil, err
 		}
 
-		args = append(args, obj)
-
+		args = append(args, objs)
 	}
 
 	return args, nil

--- a/internal/sh/fncall.go
+++ b/internal/sh/fncall.go
@@ -93,7 +93,8 @@ func (fn *UserFn) SetArgs(args []sh.Obj) error {
 		}
 	}
 
-	for i := 0; i < len(fn.argNames); i++ {
+	var i int
+	for i = 0; i < len(fn.argNames) && i < len(args); i++ {
 		arg := args[i]
 		argName := fn.argNames[i].Name
 		isVariadic := fn.argNames[i].IsVariadic
@@ -109,6 +110,15 @@ func (fn *UserFn) SetArgs(args []sh.Obj) error {
 		} else {
 			fn.Setvar(argName, arg)
 		}
+	}
+
+	// set remaining (variadic) list
+	if len(fn.argNames) > 0 && i < len(fn.argNames) {
+		last := fn.argNames[len(fn.argNames)-1]
+		if !last.IsVariadic {
+			return errors.NewError("internal error: optional arguments only for variadic parameter")
+		}
+		fn.Setvar(last.Name, sh.NewListObj([]sh.Obj{}))
 	}
 
 	return nil

--- a/internal/sh/fncall.go
+++ b/internal/sh/fncall.go
@@ -58,8 +58,7 @@ func (fn *UserFn) SetArgs(args []sh.Obj) error {
 		countNormalArgs int
 	)
 
-	for i := 0; i < len(fn.argNames); i++ {
-		argName := fn.argNames[i]
+	for i, argName := range fn.argNames {
 		if argName.IsVariadic {
 			if i != len(fn.argNames)-1 {
 				return errors.NewError("variadic expansion must be last argument")

--- a/internal/sh/fncall.go
+++ b/internal/sh/fncall.go
@@ -16,7 +16,7 @@ type (
 	}
 
 	UserFn struct {
-		argNames []FnArg    // argNames store parameter name
+		argNames []sh.FnArg // argNames store parameter name
 		done     chan error // for async execution
 		results  []sh.Obj
 
@@ -46,9 +46,9 @@ func NewUserFn(name string, parent *Shell) (*UserFn, error) {
 	return &fn, nil
 }
 
-func (fn *UserFn) ArgNames() []FnArg { return fn.argNames }
+func (fn *UserFn) ArgNames() []sh.FnArg { return fn.argNames }
 
-func (fn *UserFn) AddArgName(arg FnArg) {
+func (fn *UserFn) AddArgName(arg sh.FnArg) {
 	fn.argNames = append(fn.argNames, arg)
 }
 
@@ -58,7 +58,7 @@ func (fn *UserFn) SetArgs(args []sh.Obj) error {
 			fn.name, len(fn.argNames), len(args))
 	}
 
-	for i := 0; i < len(args); i++ {
+	for i := 0; i < len(fn.argNames); i++ {
 		arg := args[i]
 		argName := fn.argNames[i].Name
 		isVariadic := fn.argNames[i].IsVariadic
@@ -68,7 +68,6 @@ func (fn *UserFn) SetArgs(args []sh.Obj) error {
 				return errors.NewError("variadic expansion must be last argument")
 			}
 			var valist []sh.Obj
-
 			for ; i < len(args); i++ {
 				arg = args[i]
 				valist = append(valist, arg)

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -956,7 +956,6 @@ func (shell *Shell) executePipe(pipe *ast.PipeNode) (sh.Obj, error) {
 		}
 
 		err = cmd.SetArgs(args)
-
 		if err != nil {
 			errIndex = i
 			goto pipeError

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -1887,7 +1887,6 @@ func (shell *Shell) executeExecAssignFn(v ast.Node) error {
 	}
 
 	fnValues, err = shell.executeFnInv(cmd.(*ast.FnInvNode))
-
 	if err != nil {
 		return err
 	}
@@ -2058,7 +2057,6 @@ func (shell *Shell) executeFnInv(n *ast.FnInvNode) ([]sh.Obj, error) {
 		fn = objfn.Fn()
 	} else {
 		fn, ok = shell.GetBuiltin(fnName)
-
 		if !ok {
 			fn, ok = shell.GetFn(fnName)
 
@@ -2076,17 +2074,20 @@ func (shell *Shell) executeFnInv(n *ast.FnInvNode) ([]sh.Obj, error) {
 
 	err = fn.SetArgs(args)
 	if err != nil {
-		return nil, err
+		return nil, errors.NewEvalError(shell.filename,
+			n, err.Error())
 	}
 
 	err = fn.Start()
 	if err != nil {
-		return nil, err
+		return nil, errors.NewEvalError(shell.filename,
+			n, err.Error())
 	}
 
 	err = fn.Wait()
 	if err != nil {
-		return nil, err
+		return nil, errors.NewEvalError(shell.filename,
+			n, err.Error())
 	}
 
 	return fn.Results(), nil
@@ -2174,6 +2175,9 @@ func (shell *Shell) executeFor(n *ast.ForNode) ([]sh.Obj, error) {
 	} else if inExpr.Type() == ast.NodeFnInv {
 		var objs []sh.Obj
 		objs, err = shell.executeFnInv(inExpr.(*ast.FnInvNode))
+		if err != nil {
+			return nil, err
+		}
 
 		if len(objs) != 1 {
 			return nil, errors.NewEvalError(shell.filename,

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -2323,6 +2323,22 @@ print("%s %s %s %s", $args...)`,
 println()`,
 			expectedStdout: "\n",
 		},
+		{
+			desc: "the first argument isn't optional",
+			execStr: `fn a(b, c...) {
+    print($b, $c...)
+}
+a("test")`,
+			expectedStdout: "test",
+		},
+		{
+			desc: "the first argument isn't optional",
+			execStr: `fn a(b, c...) {
+    print($b, $c...)
+}
+a()`,
+			expectedErr: "Wrong number of arguments for function a. Expected at least 1 arguments but found 0",
+		},
 	} {
 		testExec(t, test)
 	}

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -2342,6 +2342,24 @@ println("%s%s%s%s%s%s%s%s%s%s", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10
 			expectedErr:    "",
 		},
 		{
+			desc: "passing list to var arg fn",
+			execStr: `fn puts(arg...) { for a in $arg { echo $a } }
+				a = ("1" "2" "3" "4" "5")
+				puts($a...)`,
+			expectedErr:    "",
+			expectedStdout: "1\n2\n3\n4\n5\n",
+			expectedStderr: "",
+		},
+		{
+			desc: "passing empty list to var arg fn",
+			execStr: `fn puts(arg...) { for a in $arg { echo $a } }
+				a = ()
+				puts($a...)`,
+			expectedErr:    "",
+			expectedStdout: "",
+			expectedStderr: "",
+		},
+		{
 			desc: "... expansion",
 			execStr: `args = ("plan9" "from" "outer" "space")
 print("%s %s %s %s", $args...)`,
@@ -2382,7 +2400,7 @@ a("test")`,
     print($b, $c...)
 }
 a()`,
-			expectedErr: "Wrong number of arguments for function a. Expected at least 1 arguments but found 0",
+			expectedErr: "<interactive>:4:0: Wrong number of arguments for function a. Expected at least 1 arguments but found 0",
 		},
 	} {
 		testExec(t, test)

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -2312,6 +2312,17 @@ print("%s %s %s %s", $args...)`,
 			execStr:     `fn println(arg..., fmt) {}`,
 			expectedErr: "<interactive>:1:11: Vararg 'arg...' isn't the last argument",
 		},
+		{
+			desc: "variadic argument are optional",
+			execStr: `fn println(b...) {
+	for v in $b {
+		print($v)
+	}
+	print("\n")
+}
+println()`,
+			expectedStdout: "\n",
+		},
 	} {
 		testExec(t, test)
 	}

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -2273,3 +2273,46 @@ world`)
 		return
 	}
 }
+
+func TestExecuteVariadicFn(t *testing.T) {
+	for _, test := range []execTestCase{
+		{
+			desc: "println",
+			execStr: `fn println(fmt, arg...) {
+	print($fmt+"\n", $arg...)
+}
+println("%s %s", "test", "test")`,
+			expectedStdout: "test test\n",
+			expectedStderr: "",
+			expectedErr:    "",
+		},
+		{
+			desc: "lots of args",
+			execStr: `fn println(fmt, arg...) {
+	print($fmt+"\n", $arg...)
+}
+println("%s%s%s%s%s%s%s%s%s%s", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10")`,
+			expectedStdout: "12345678910\n",
+			expectedStderr: "",
+			expectedErr:    "",
+		},
+		{
+			desc: "... expansion",
+			execStr: `args = ("plan9" "from" "outer" "space")
+print("%s %s %s %s", $args...)`,
+			expectedStdout: "plan9 from outer space",
+		},
+		{
+			desc:           "literal ... expansion",
+			execStr:        `print("%s:%s:%s", ("a" "b" "c")...)`,
+			expectedStdout: "a:b:c",
+		},
+		{
+			desc:        "varargs only as last argument",
+			execStr:     `fn println(arg..., fmt) {}`,
+			expectedErr: "<interactive>:1:11: Vararg 'arg...' isn't the last argument",
+		},
+	} {
+		testExec(t, test)
+	}
+}

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -169,25 +169,42 @@ func TestExecuteFile(t *testing.T) {
 func TestExecuteCommand(t *testing.T) {
 	for _, test := range []execTestCase{
 		{
-			"command failed",
-			`non-existing-program`,
-			"", "",
-			`exec: "non-existing-program": executable file not found in $PATH`,
+			desc:           "command failed",
+			execStr:        `non-existing-program`,
+			expectedStdout: "",
+			expectedStderr: "",
+			expectedErr:    `exec: "non-existing-program": executable file not found in $PATH`,
 		},
 		{
-			"err ignored",
-			`-non-existing-program`,
-			"", "", "",
+			desc:           "err ignored",
+			execStr:        `-non-existing-program`,
+			expectedStdout: "",
+			expectedStderr: "",
+			expectedErr:    "",
 		},
 		{
-			"hello world",
-			"echo -n hello world",
-			"hello world", "", "",
+			desc:           "hello world",
+			execStr:        "echo -n hello world",
+			expectedStdout: "hello world",
+			expectedStderr: "",
+			expectedErr:    "",
 		},
 		{
-			"cmd with concat",
-			`echo -n "hello " + "world"`,
-			"hello world", "", "",
+			desc:           "cmd with concat",
+			execStr:        `echo -n "hello " + "world"`,
+			expectedStdout: "hello world",
+			expectedStderr: "",
+			expectedErr:    "",
+		},
+		{
+			desc: "local command",
+			execStr: `echopath <= which echo
+path <= dirname $echopath
+chdir($path)
+./echo -n hello`,
+			expectedStdout: "hello",
+			expectedStderr: "",
+			expectedErr:    "",
 		},
 	} {
 		testExec(t, test)

--- a/nash_test.go
+++ b/nash_test.go
@@ -107,7 +107,6 @@ func TestExecuteString(t *testing.T) {
 
 func TestSetDotDir(t *testing.T) {
 	shell, err := New()
-
 	if err != nil {
 		t.Error(err)
 		return
@@ -116,18 +115,15 @@ func TestSetDotDir(t *testing.T) {
 	var out bytes.Buffer
 
 	shell.SetStdout(&out)
-
 	shell.SetDotDir("/tmp")
 
 	dotDir := shell.DotDir()
-
 	if dotDir != "/tmp" {
 		t.Errorf("Invalid .nash = %s", dotDir)
 		return
 	}
 
 	err = shell.ExecuteString("-ínput-", "echo -n $NASHPATH")
-
 	if err != nil {
 		t.Error(err)
 		return

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -662,7 +662,6 @@ hasConcat:
 		p.ignore()
 
 		arg, err := p.getArgument(true, false, false)
-
 		if err != nil {
 			return nil, err
 		}

--- a/parser/parse_regression_test.go
+++ b/parser/parse_regression_test.go
@@ -15,8 +15,8 @@ func TestParseIssue22(t *testing.T) {
 	expected := ast.NewTree("issue 22")
 	ln := ast.NewBlockNode(token.NewFileInfo(1, 0))
 
-	fn := ast.NewFnDeclNode(token.NewFileInfo(1, 0), "gocd")
-	fn.AddArg("path")
+	fn := ast.NewFnDeclNode(token.NewFileInfo(1, 3), "gocd")
+	fn.AddArg(ast.NewFnArgNode(token.NewFileInfo(1, 8), "path", false))
 
 	fnTree := ast.NewTree("fn")
 	fnBlock := ast.NewBlockNode(token.NewFileInfo(1, 0))
@@ -107,7 +107,7 @@ func TestParseIssue43(t *testing.T) {
 	expected := ast.NewTree("parse issue 41")
 	ln := ast.NewBlockNode(token.NewFileInfo(1, 0))
 
-	fnDecl := ast.NewFnDeclNode(token.NewFileInfo(1, 0), "gpull")
+	fnDecl := ast.NewFnDeclNode(token.NewFileInfo(1, 3), "gpull")
 	fnTree := ast.NewTree("fn")
 	fnBlock := ast.NewBlockNode(token.NewFileInfo(1, 0))
 

--- a/parser/parse_regression_test.go
+++ b/parser/parse_regression_test.go
@@ -74,21 +74,15 @@ func TestParseIssue22(t *testing.T) {
 
 func TestParseIssue38(t *testing.T) {
 	expected := ast.NewTree("parse issue38")
-
 	ln := ast.NewBlockNode(token.NewFileInfo(1, 0))
-
 	fnInv := ast.NewFnInvNode(token.NewFileInfo(1, 0), "cd")
-
 	args := make([]ast.Expr, 3)
-
 	args[0] = ast.NewVarExpr(token.NewFileInfo(1, 3), "$GOPATH")
 	args[1] = ast.NewStringExpr(token.NewFileInfo(1, 12), "/src/", true)
 	args[2] = ast.NewVarExpr(token.NewFileInfo(1, 19), "$path")
 
 	arg := ast.NewConcatExpr(token.NewFileInfo(1, 3), args)
-
 	fnInv.AddArg(arg)
-
 	ln.Push(fnInv)
 	expected.Root = ln
 

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -618,6 +618,16 @@ func TestParseCd(t *testing.T) {
 
 	parserTest("test cd into home", "cd", expected, t, true)
 
+	// test cd ..
+	expected = ast.NewTree("test cd ..")
+	ln = ast.NewBlockNode(token.NewFileInfo(1, 0))
+	cd = ast.NewCommandNode(token.NewFileInfo(1, 0), "cd", false)
+	cd.AddArg(ast.NewStringExpr(token.NewFileInfo(1, 3), "..", false))
+	ln.Push(cd)
+	expected.Root = ln
+
+	parserTest("test cd ..", "cd ..", expected, t, true)
+
 	expected = ast.NewTree("cd into HOME by setenv")
 	ln = ast.NewBlockNode(token.NewFileInfo(1, 0))
 

--- a/parser/parse_test.go
+++ b/parser/parse_test.go
@@ -1125,7 +1125,7 @@ func TestParseFnBasic(t *testing.T) {
 	ln := ast.NewBlockNode(token.NewFileInfo(1, 0))
 
 	// fn
-	fn := ast.NewFnDeclNode(token.NewFileInfo(1, 0), "build")
+	fn := ast.NewFnDeclNode(token.NewFileInfo(1, 3), "build")
 	tree := ast.NewTree("fn body")
 	lnBody := ast.NewBlockNode(token.NewFileInfo(1, 0))
 	tree.Root = lnBody
@@ -1144,7 +1144,7 @@ func TestParseFnBasic(t *testing.T) {
 	ln = ast.NewBlockNode(token.NewFileInfo(1, 0))
 
 	// fn
-	fn = ast.NewFnDeclNode(token.NewFileInfo(1, 0), "build")
+	fn = ast.NewFnDeclNode(token.NewFileInfo(1, 3), "build")
 	tree = ast.NewTree("fn body")
 	lnBody = ast.NewBlockNode(token.NewFileInfo(1, 0))
 	cmd := ast.NewCommandNode(token.NewFileInfo(1, 0), "ls", false)
@@ -1165,8 +1165,8 @@ func TestParseFnBasic(t *testing.T) {
 	ln = ast.NewBlockNode(token.NewFileInfo(1, 0))
 
 	// fn
-	fn = ast.NewFnDeclNode(token.NewFileInfo(1, 0), "build")
-	fn.AddArg("image")
+	fn = ast.NewFnDeclNode(token.NewFileInfo(1, 3), "build")
+	fn.AddArg(ast.NewFnArgNode(token.NewFileInfo(1, 9), "image", false))
 	tree = ast.NewTree("fn body")
 	lnBody = ast.NewBlockNode(token.NewFileInfo(1, 0))
 	cmd = ast.NewCommandNode(token.NewFileInfo(1, 0), "ls", false)
@@ -1187,9 +1187,9 @@ func TestParseFnBasic(t *testing.T) {
 	ln = ast.NewBlockNode(token.NewFileInfo(1, 0))
 
 	// fn
-	fn = ast.NewFnDeclNode(token.NewFileInfo(1, 0), "build")
-	fn.AddArg("image")
-	fn.AddArg("debug")
+	fn = ast.NewFnDeclNode(token.NewFileInfo(1, 3), "build")
+	fn.AddArg(ast.NewFnArgNode(token.NewFileInfo(1, 9), "image", false))
+	fn.AddArg(ast.NewFnArgNode(token.NewFileInfo(1, 16), "debug", false))
 	tree = ast.NewTree("fn body")
 	lnBody = ast.NewBlockNode(token.NewFileInfo(1, 0))
 	cmd = ast.NewCommandNode(token.NewFileInfo(1, 0), "ls", false)
@@ -1210,7 +1210,7 @@ func TestParseInlineFnDecl(t *testing.T) {
 	expected := ast.NewTree("fn")
 	ln := ast.NewBlockNode(token.NewFileInfo(1, 0))
 
-	fn := ast.NewFnDeclNode(token.NewFileInfo(1, 0), "cd")
+	fn := ast.NewFnDeclNode(token.NewFileInfo(1, 3), "cd")
 	tree := ast.NewTree("fn body")
 	lnBody := ast.NewBlockNode(token.NewFileInfo(1, 0))
 	echo := ast.NewCommandNode(token.NewFileInfo(1, 11), "echo", false)
@@ -1577,6 +1577,70 @@ func TestMultiPipe(t *testing.T) {
 	echo "hello world" |
 	awk "{print AAAAAAAAAAAAAAAAAAAAAA}"
 )`, expected, t, true)
+}
+
+func TestFnVariadic(t *testing.T) {
+	// root
+	expected := ast.NewTree("variadic")
+	ln := ast.NewBlockNode(token.NewFileInfo(1, 0))
+
+	// fn
+	fn := ast.NewFnDeclNode(token.NewFileInfo(1, 3), "println")
+	fn.AddArg(ast.NewFnArgNode(token.NewFileInfo(1, 11), "fmt", false))
+	fn.AddArg(ast.NewFnArgNode(token.NewFileInfo(1, 16), "arg", true))
+	tree := ast.NewTree("fn body")
+	lnBody := ast.NewBlockNode(token.NewFileInfo(1, 0))
+	print := ast.NewFnInvNode(token.NewFileInfo(2, 2), "print")
+	print.AddArg(ast.NewConcatExpr(token.NewFileInfo(1, 7), []ast.Expr{
+		ast.NewVarExpr(token.NewFileInfo(2, 7), "$fmt"),
+		ast.NewStringExpr(token.NewFileInfo(2, 12), "\n", true),
+	}))
+	print.AddArg(ast.NewVarVariadicExpr(token.NewFileInfo(2, 12), "$arg", true))
+	lnBody.Push(print)
+	tree.Root = lnBody
+	fn.SetTree(tree)
+
+	// root
+	ln.Push(fn)
+	expected.Root = ln
+
+	parserTest("fn", `fn println(fmt, arg...) {
+	print($fmt+"\n", $arg...)
+}`, expected, t, true)
+}
+
+func TestParseValidDotdotdot(t *testing.T) {
+	for _, tc := range []string{
+		// things that should not break
+		"ls ...",
+		"go get ./...",
+		`echo "..."`,
+		`strangecmd... -h`,
+		`bad_designed...fail -f`,
+	} {
+		parser := NewParser("", tc)
+		_, err := parser.Parse()
+		if err != nil {
+			t.Fatalf("Code: '%s' failed: %s", tc, err.Error())
+		}
+	}
+}
+
+func TestParseInvalidDotdotdot(t *testing.T) {
+	for _, tc := range []string{
+		"...",
+		`if ... == "" {}`,
+		`if $var... == "" {}`,
+		`a = $var...`,
+		`a, b, c = ("a" "b" "c")...`, // please, no
+		// `fn println(arg..., fmt) {}`, // Not sure if must fail at parsing...
+	} {
+		parser := NewParser("", tc)
+		_, err := parser.Parse()
+		if err == nil {
+			t.Fatalf("Syntax '%s' must fail", tc)
+		}
+	}
 }
 
 func TestFunctionPipes(t *testing.T) {

--- a/scanner/lex.go
+++ b/scanner/lex.go
@@ -286,7 +286,8 @@ func lexStart(l *Lexer) stateFn {
 		if next != eof && !isSpace(next) &&
 			!isEndOfLine(next) && next != ';' &&
 			next != ')' && next != ',' && next != '+' &&
-			next != '[' && next != ']' && next != '(' {
+			next != '[' && next != ']' && next != '(' &&
+			next != '.' {
 			l.errorf("Unrecognized character in action: %#U", next)
 			return nil
 		}
@@ -348,6 +349,17 @@ func lexStart(l *Lexer) stateFn {
 		return lexStart
 	case r == ',':
 		l.emit(token.Comma)
+		return lexStart
+	case r == '.':
+		if r = l.peek(); r != '.' {
+			return lexStart
+		}
+		l.next()
+		if r = l.peek(); r != '.' {
+			return lexStart
+		}
+		l.next()
+		l.emit(token.Dotdotdot)
 		return lexStart
 	case isIdentifier(r):
 		// nash literals are lowercase

--- a/scanner/lex.go
+++ b/scanner/lex.go
@@ -378,6 +378,24 @@ func lexStart(l *Lexer) stateFn {
 			} else {
 				l.emit(token.Ident)
 			}
+		} else if next == '.' {
+			ident := l.input[l.start:l.pos]
+			identLine, identCol := l.lineStart, l.columnStart
+			dotLine, dotColumn := l.line, l.column
+			l.next()
+			next = l.peek()
+			if next == '.' {
+				l.next()
+				next = l.peek()
+				if next == '.' {
+					l.next()
+					l.emitVal(token.Ident, ident, identLine, identCol)
+					l.emitVal(token.Dotdotdot, "...", dotLine, dotColumn)
+					return lexStart
+				}
+			}
+			absorbArgument(l)
+			l.emit(token.Arg)
 		} else {
 			absorbArgument(l)
 			l.emit(token.Arg)

--- a/scanner/lex.go
+++ b/scanner/lex.go
@@ -364,6 +364,11 @@ func lexStart(l *Lexer) stateFn {
 		}
 		absorbArgument(l)
 		l.emit(token.Arg)
+		if next == eof && l.openParens > 0 {
+			l.addSemicolon = false
+		} else {
+			l.addSemicolon = true
+		}
 		return lexStart
 	case isIdentifier(r):
 		// nash literals are lowercase

--- a/scanner/lex_test.go
+++ b/scanner/lex_test.go
@@ -1827,3 +1827,30 @@ func TestLexerLongAssignment(t *testing.T) {
 	jq ".GroupId" |
 	xargs echo -n)`, expected, t)
 }
+
+func TestLexerVarArgs(t *testing.T) {
+	expected := []Token{
+		{typ: token.Ident, val: "println"},
+		{typ: token.LParen, val: "("},
+		{typ: token.Ident, val: "fmt"},
+		{typ: token.Comma, val: ","},
+		{typ: token.Dotdotdot, val: "..."},
+		{typ: token.Ident, val: "args"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.LBrace, val: "{"},
+		{typ: token.Ident, val: "print"},
+		{typ: token.LParen, val: "("},
+		{typ: token.Variable, val: "$fmt"},
+		{typ: token.Comma, val: ","},
+		{typ: token.Variable, val: "$args"},
+		{typ: token.Dotdotdot, val: "..."},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.RBrace, val: "}"},
+		{typ: token.EOF},
+	}
+
+	testTable("test var args", `println(fmt, ...args) {
+	print($fmt, $args...)
+}`, expected, t)
+}

--- a/scanner/lex_test.go
+++ b/scanner/lex_test.go
@@ -1853,8 +1853,8 @@ func TestLexerVarArgs(t *testing.T) {
 		{typ: token.LParen, val: "("},
 		{typ: token.Ident, val: "fmt"},
 		{typ: token.Comma, val: ","},
-		{typ: token.Dotdotdot, val: "..."},
 		{typ: token.Ident, val: "args"},
+		{typ: token.Dotdotdot, val: "..."},
 		{typ: token.RParen, val: ")"},
 		{typ: token.LBrace, val: "{"},
 		{typ: token.Ident, val: "print"},
@@ -1869,7 +1869,31 @@ func TestLexerVarArgs(t *testing.T) {
 		{typ: token.EOF},
 	}
 
-	testTable("test var args", `println(fmt, ...args) {
+	testTable("test var args", `println(fmt, args...) {
 	print($fmt, $args...)
 }`, expected, t)
+	testTable("test var args", `println(fmt, args ...) {
+	print($fmt, $args...)
+}`, expected, t)
+
+	expected = []Token{
+		{typ: token.Ident, val: "print"},
+		{typ: token.LParen, val: "("},
+		{typ: token.String, val: "%s:%s:%s"},
+		{typ: token.Comma, val: ","},
+		{typ: token.LParen, val: "("},
+		{typ: token.String, val: "a"},
+		{typ: token.String, val: "b"},
+		{typ: token.String, val: "c"},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Dotdotdot, val: "..."},
+		{typ: token.RParen, val: ")"},
+		{typ: token.Semicolon, val: ";"},
+		{typ: token.EOF},
+	}
+
+	testTable("test literal expansion", `print("%s:%s:%s", ("a" "b" "c")...)`,
+		expected, t)
+	testTable("test literal expansion", `print("%s:%s:%s", ("a" "b" "c") ...)`,
+		expected, t)
 }

--- a/scanner/lex_test.go
+++ b/scanner/lex_test.go
@@ -432,6 +432,14 @@ func TestLexerSimpleCommand(t *testing.T) {
 
 	testTable("testSimpleCommand", `ls "/home/user" + "/.gvm/pkgsets/global/src"`, expected, t)
 
+	expected = []Token{
+		{typ: token.Arg, val: "./rkt"},
+		{typ: token.Semicolon, val: ";"}, // automatic semicolon insertion
+		{typ: token.EOF},
+	}
+
+	testTable("test local command", "./rkt", expected, t)
+
 }
 
 func TestLexerPipe(t *testing.T) {

--- a/sh/shell.go
+++ b/sh/shell.go
@@ -21,12 +21,24 @@ type (
 		Stderr() io.Writer
 	}
 
+	FnArg struct {
+		Name       string
+		IsVariadic bool
+	}
+
 	Fn interface {
 		Name() string
-		ArgNames() []string
+		ArgNames() []FnArg
 
 		Runner
 
 		String() string
 	}
 )
+
+func NewFnArg(name string, isVariadic bool) FnArg {
+	return FnArg{
+		Name:       name,
+		IsVariadic: isVariadic,
+	}
+}

--- a/spec.ebnf
+++ b/spec.ebnf
@@ -50,7 +50,7 @@ fnDecl = "fn" identifier "(" fnArgs ")" "{"
          program [ returnDecl ]
          "}" .
 fnArgs = { fnArg [ "," ] } .
-fnArg  = identifier .
+fnArg  = identifier [ "..." ] .
 
 /* return declaration */
 returnDecl = "return" [ ( variable | stringLit | list | fnInv ) ] .
@@ -59,7 +59,7 @@ returnDecl = "return" [ ( variable | stringLit | list | fnInv ) ] .
 fnInv = ( variable | identifier ) "(" fnArgValues ")" .
 
 fnArgValues = { fnArgValue [ "," ] } .
-fnArgValue  = [ stringLit | stringConcat | variable | fnInv ] .
+fnArgValue  = [ stringLit | stringConcat | (variable [ "..." ]) | (list [ "..." ]) fnInv ] .
 
 /* Function binding */
 bindfn = "bindfn" identifier identifier .

--- a/token/token.go
+++ b/token/token.go
@@ -49,6 +49,7 @@ const (
 	Pipe
 
 	Comma
+	Dotdotdot
 
 	Variable
 
@@ -99,7 +100,8 @@ var tokens = [...]string{
 	RBrack: "]",
 	Pipe:   "|",
 
-	Comma: ",",
+	Comma:     ",",
+	Dotdotdot: "...",
 
 	Variable: "VARIABLE",
 


### PR DESCRIPTION
The '...' syntax was added to declare functions that can receive any number of arguments. 

- A ... parameter is received as a list inside the function.

```sh
fn println(args...) {
        for a in $args {
                print($a)
        }
        print("\n")
}
```
- A ... parameter is optional
```sh
println() # Output: \n

fn a(b, c...) {
    print($b, $c...)
}
a("test") # Output: test
a() # Fail, requires at least one argument.
```
- As a special case, the ... expansion is allowed in command arguments to pass a list as multiples arguments.

```sh
# The commands below are equivalent
curl $args
curl $args...
```

This is only a first proposal, feel free to criticize.

I believe now we can change the `print` builtin to just print (no format) and then add the following functions as nash stdlib:

```sh
fn printf(fmt, args...) {
    print(format(fmt, $args...))
}

fn println(args...) {
        for arg in $args {
                print($arg)
        }
        print("\n")
}

# and so on
```