### PR TITLE
Add goreleaser to easy the release process

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,0 +1,49 @@
+# goreleaser.yml
+build:
+  # Path to main.go file or main package.
+  # Default is `.`
+  main: ./cmd/nash/main.go
+
+  # Name of the binary.
+  # Default is the name of the project directory.
+  binary: nash
+
+  # Custom ldflags template.
+  # This is parsed with Golang template engine and the following variables
+  # are available:
+  # - Date
+  # - Commit
+  # - Tag
+  # - Version (Tag with the `v` prefix stripped)
+  # The default is `-s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}`
+  # Date format is `2006-01-02_15:04:05`
+  ldflags: -s -w -X main.VersionString={{.Version}}
+  goos:
+    - linux
+    - darwin
+    - freebsd
+    - windows
+
+  goarch:
+    - 386
+    - amd64
+#    - arm64
+
+#  goarm:
+#    - 6
+#    - 7
+
+  # List of combinations of GOOS + GOARCH + GOARM to ignore.
+  # Default is empty.
+  ignore:
+    - goos: darwin
+      goarch: 386
+
+release:
+  github:
+    owner: NeowayLabs
+    name: nash
+
+  # If set to true, will not auto-publish the release.
+  # Default is false
+  draft: true

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -2,7 +2,7 @@
 build:
   # Path to main.go file or main package.
   # Default is `.`
-  main: ./cmd/nash/main.go
+  main: ./cmd/nash
 
   # Name of the binary.
   # Default is the name of the project directory.


### PR DESCRIPTION
Am I missing something?

Bonus of using it:

- Very easy configurable release
- Cross build on every arch/os that Go supports
- Integrates with Travis-CI (auto-generate releases)

Problems I found with goreleaser:

- There's no way to configure different ldflags to each $GOOS
- There's no way to pass build flags to the compiler
- There's no way to release multiple set of binaries (like nash and nashfmt)

Given the limitation of goreleaser, this configuration has the following impacts:

- Nash binary will not be static when building with Go < 1.5
- Nash binary will use the host net resolver instead of netgo when building with Go < 1.5
- Nashfmt isn't shipped in the release...

What do you guys think? Is a good move?