### PR TITLE
stdbin: adding mkdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ buildargs = -ldflags "-X main.VersionString=$(version)" -v
 all: build test install
 
 build:
-	go build $(buildargs) -o ./cmd/nash/nash ./cmd/nash
-	go build $(buildargs) -o ./cmd/nashfmt/nashfmt ./cmd/nashfmt
+	cd cmd/nash && go build $(buildargs) 
+	cd cmd/nashfmt && go build $(buildargs) 
+	cd stdbin/mkdir && go build $(buildargs)
 
 NASHPATH=$(HOME)/nash
 NASHROOT=$(HOME)/nashroot
@@ -23,6 +24,7 @@ install: build
 	cp -p ./cmd/nashfmt/nashfmt $(NASHROOT)/bin
 	rm -rf $(NASHROOT)/stdlib
 	cp -pr ./stdlib $(NASHROOT)/stdlib
+	cp -pr ./stdbin/mkdir/mkdir $(NASHROOT)/bin/mkdir
 
 deps:
 	go get -v -t golang.org/x/exp/ebnf

--- a/stdbin/mkdir/main.go
+++ b/stdbin/mkdir/main.go
@@ -22,7 +22,7 @@ func main() {
 	}
 	err := mkdirs(os.Args[1:])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/stdbin/mkdir/main.go
+++ b/stdbin/mkdir/main.go
@@ -1,0 +1,28 @@
+package main 
+
+import (
+	"os"
+	"fmt"
+)
+
+func mkdirs(dirnames []string) error {
+	for _, d := range dirnames {
+		if err := os.MkdirAll(d, 0644); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <dir1> <dir2> ...\n", os.Args[0])
+		os.Exit(1)
+	}
+	err := mkdirs(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err.Error())
+		os.Exit(1)
+	}
+}

--- a/stdbin/mkdir/mkdir_test.go
+++ b/stdbin/mkdir/mkdir_test.go
@@ -1,0 +1,40 @@
+package main 
+
+import (
+	"testing"
+	"path"
+	"path/filepath"
+	"io/ioutil"
+	"os"
+	"fmt"
+)
+
+func TestMkdir(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "nash-mkdir")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testDirs := []string{
+		"1", "2", "3", "4", "5",
+		"some", "thing", "_random_",
+		"_",
+	}
+
+	defer os.RemoveAll(tmpDir)
+	for _, p := range testDirs {
+		testdir := filepath.FromSlash(path.Join(tmpDir, p))
+		err = mkdirs([]string{testdir})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fmt.Println(testdir)
+
+		if s, err := os.Stat(testdir); err != nil {
+			t.Fatal(err)
+		} else if s.Mode()&os.ModeDir != os.ModeDir {
+			t.Errorf("Invalid directory mode: %v", s.Mode())
+		}
+	}
+}

--- a/stdbin/mkdir/mkdir_test.go
+++ b/stdbin/mkdir/mkdir_test.go
@@ -29,8 +29,6 @@ func TestMkdir(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		fmt.Println(testdir)
-
 		if s, err := os.Stat(testdir); err != nil {
 			t.Fatal(err)
 		} else if s.Mode()&os.ModeDir != os.ModeDir {

--- a/stdbin/mkdir/mkdir_test.go
+++ b/stdbin/mkdir/mkdir_test.go
@@ -51,7 +51,7 @@ func TestMkdir(t *testing.T) {
 			},
 		},
 		{
-			dirs: []string{},
+			dirs: []string{"a", "a"}, // directory already exists, silently works
 		},
 	} {
 		tc := tc 


### PR DESCRIPTION
This PR starts a long road to address #230. 

As I'm using a lot of windows nowadays... I'll start scratching my itches, by adding the programs I'm missing in windows. The work for the stdbin build system and integrated tests could come up in another PR.

Another PR could be created to copy our programs from c0defellas/enzo to here also.

p.s.: the name of the branch is `add-stdbin-pwd` because `pwd` was my initial target for this development, but soon realized I was unable to create the stdbin directory in windows without _right-click in explorer_ ... Then mkdir priority escalated very fast =P