### PR TITLE
Fix bindfn vargs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ sudo: false
 
 go:
   - tip
-  - 1.8
-  - 1.7
+  - 1.9
 install:
   - go get -v golang.org/x/exp/ebnf
   - make build

--- a/internal/sh/builtin/chdir.go
+++ b/internal/sh/builtin/chdir.go
@@ -1,6 +1,7 @@
 package builtin
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -24,8 +25,12 @@ func (chdir *chdirFn) ArgNames() []sh.FnArg {
 	}
 }
 
-func (chdir *chdirFn) Run(in io.Reader, out io.Writer, err io.Writer) ([]sh.Obj, error) {
-	return nil, os.Chdir(chdir.arg)
+func (chdir *chdirFn) Run(in io.Reader, out io.Writer, ioerr io.Writer) ([]sh.Obj, error) {
+	err := os.Chdir(chdir.arg)
+	if err != nil {
+		err = fmt.Errorf("builtin: chdir: error[%s] path[%s]", err, chdir.arg)
+	}
+	return nil, err
 }
 
 func (chdir *chdirFn) SetArgs(args []sh.Obj) error {

--- a/internal/sh/functions_test.go
+++ b/internal/sh/functions_test.go
@@ -6,7 +6,7 @@ func TestFunctionsClosures(t *testing.T) {
 	for _, test := range []execTestCase{
 		{
 			desc: "simpleClosure",
-			execStr: `
+			code: `
 				fn func(a) {
 					fn closure() {
 						print($a)
@@ -23,7 +23,7 @@ func TestFunctionsClosures(t *testing.T) {
 		},
 		{
 			desc: "eachCallCreatesNewVar",
-			execStr: `
+			code: `
 				fn func() {
 					a = ()
 					fn add(elem) {
@@ -42,7 +42,7 @@ func TestFunctionsClosures(t *testing.T) {
 		},
 		{
 			desc: "adder example",
-			execStr: `
+			code: `
 fn makeAdder(x) {
     fn add(y) {
         ret <= expr $x "+" $y
@@ -74,7 +74,7 @@ print("%s\n", add1("10"))
 		},
 		{
 			desc: "logger",
-			execStr: `fn getlogger(prefix) {
+			code: `fn getlogger(prefix) {
     fn log(fmt, args...) {
         print($prefix+$fmt+"\n", $args...)
     }
@@ -106,7 +106,7 @@ func TestFunctionsVariables(t *testing.T) {
 	for _, test := range []execTestCase{
 		{
 			desc: "fn stored only as vars",
-			execStr: `
+			code: `
 				fn func(a) {
 					echo -n "hello"
 				}
@@ -129,7 +129,7 @@ func TestFunctionsStateless(t *testing.T) {
 	for _, test := range []execTestCase{
 		{
 			desc: "functions have no shared state",
-			execStr: `fn iter(first, last, func) {
+			code: `fn iter(first, last, func) {
    sequence <= seq $first $last
    range <= split($sequence, "\n")
    for i in $range {

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -1278,7 +1278,7 @@ func (shell *Shell) buildRedirect(cmd sh.Runner, redirDecl *ast.RedirectNode) ([
 	return closeAfterWait, err
 }
 
-func (shell *Shell) runBindfn(
+func (shell *Shell) newBindfnRunner(
 	c *ast.CommandNode,
 	cmdName string,
 	fnDef sh.FnDef,
@@ -1322,7 +1322,7 @@ func (shell *Shell) getCommand(c *ast.CommandNode) (sh.Runner, bool, error) {
 	}
 
 	if fnDef, ok := shell.Getbindfn(cmdName); ok {
-		runner, err := shell.runBindfn(c, cmdName, fnDef)
+		runner, err := shell.newBindfnRunner(c, cmdName, fnDef)
 		return runner, ignoreError, err
 	}
 

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -1266,6 +1266,31 @@ func (shell *Shell) buildRedirect(cmd sh.Runner, redirDecl *ast.RedirectNode) ([
 	return closeAfterWait, err
 }
 
+func (shell *Shell) runBindfn(
+	c *ast.CommandNode,
+	cmdName string,
+	fnDef sh.FnDef,
+) (sh.Runner, error) {
+	shell.logf("Executing bind %s", cmdName)
+	shell.logf("%s bind to %s", cmdName, fnDef.Name())
+
+	if !shell.Interactive() {
+		err := errors.NewEvalError(shell.filename,
+			c, "'%s' is a bind to '%s'. "+
+				"No binds allowed in non-interactive mode.",
+			cmdName,
+			fnDef.Name())
+		return nil, err
+	}
+
+	//for i := len(c.Args()); i < len(fnDef.ArgNames()); i++ {
+	//// fill missing args with empty string safe?
+	//c.SetArgs(append(c.Args(), ast.NewStringExpr(token.NewFileInfo(0, 0), "", true)))
+	//}
+
+	return fnDef.Build(), nil
+}
+
 func (shell *Shell) getCommand(c *ast.CommandNode) (sh.Runner, bool, error) {
 	var (
 		ignoreError bool
@@ -1290,35 +1315,8 @@ func (shell *Shell) getCommand(c *ast.CommandNode) (sh.Runner, bool, error) {
 	}
 
 	if fnDef, ok := shell.Getbindfn(cmdName); ok {
-		shell.logf("Executing bind %s", cmdName)
-		shell.logf("%s bind to %s", cmdName, fnDef.Name())
-
-		if !shell.Interactive() {
-			err = errors.NewEvalError(shell.filename,
-				c, "'%s' is a bind to '%s'. "+
-					"No binds allowed in non-interactive mode.",
-				cmdName,
-				fnDef.Name())
-			return nil, ignoreError, err
-		}
-
-		if len(c.Args()) > len(fnDef.ArgNames()) {
-			err = errors.NewEvalError(shell.filename,
-				c, "Too much arguments for"+
-					" function '%s'. It expects %d args, but given %d. Arguments: %q",
-				fnDef.Name(),
-				len(fnDef.ArgNames()),
-				len(c.Args()), c.Args())
-			return nil, ignoreError, err
-		}
-
-		for i := len(c.Args()); i < len(fnDef.ArgNames()); i++ {
-			// fill missing args with empty string
-			// safe?
-			c.SetArgs(append(c.Args(), ast.NewStringExpr(token.NewFileInfo(0, 0), "", true)))
-		}
-
-		return fnDef.Build(), ignoreError, nil
+		runner, err := shell.runBindfn(c, cmdName, fnDef)
+		return runner, ignoreError, err
 	}
 
 	cmd, err = NewCmd(cmdName)

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -411,10 +411,22 @@ func (shell *Shell) setupBuiltin() {
 
 func (shell *Shell) setupDefaultBindings() error {
 	// only one builtin fn... no need for advanced machinery yet
-	err := shell.Exec(shell.name, `fn nash_builtin_cd(path) {
-            if $path == "" {
+	// FIXME: does it make sense to have default bindfn ?
+	// seems a little intrusive and a very odd way to add a default
+	// bindfn (it was not trivial to found).
+	//
+	// TODO: Not sure if ignoring exceeding parameters is the way
+	// to go, but I'm not even sure if having this default bind is
+	// a good idea anyway (I have my own cd that does other things for example).
+	err := shell.Exec(shell.name, `fn nash_builtin_cd(args...) {
+	    path = ""
+	    l <= len($args)
+
+            if $l == "0" {
                     path = $HOME
-            }
+            } else {
+                    path = $args[0]
+	    }
 
             chdir($path)
         }
@@ -1282,11 +1294,6 @@ func (shell *Shell) runBindfn(
 			fnDef.Name())
 		return nil, err
 	}
-
-	//for i := len(c.Args()); i < len(fnDef.ArgNames()); i++ {
-	//// fill missing args with empty string safe?
-	//c.SetArgs(append(c.Args(), ast.NewStringExpr(token.NewFileInfo(0, 0), "", true)))
-	//}
 
 	return fnDef.Build(), nil
 }

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -411,13 +411,7 @@ func (shell *Shell) setupBuiltin() {
 
 func (shell *Shell) setupDefaultBindings() error {
 	// only one builtin fn... no need for advanced machinery yet
-	// FIXME: does it make sense to have default bindfn ?
-	// seems a little intrusive and a very odd way to add a default
-	// bindfn (it was not trivial to found).
-	//
-	// TODO: Not sure if ignoring exceeding parameters is the way
-	// to go, but I'm not even sure if having this default bind is
-	// a good idea anyway (I have my own cd that does other things for example).
+	// FIXME: seems better to have a std init than embedding here on code
 	err := shell.Exec(shell.name, `fn nash_builtin_cd(args...) {
 	    path = ""
 	    l <= len($args)

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -718,13 +718,21 @@ func TestExecuteCd(t *testing.T) {
 			expectedStdout: "/\n",
 		},
 		{
+			// FIXME: perhaps fail ? not sure
+			desc: "test cd ignores extra args",
+			code: `
+				cd / /etc /lala /ignored
+				pwd
+			`,
+			expectedStdout: "/\n",
+		},
+		{
 			desc: "test error",
 			code: `
 				var=("val1" "val2" "val3")
 				cd $var
-				pwd
 			`,
-			expectedErr: "<interactive>:2:12: lvalue is not comparable: (val1 val2 val3) -> ListType.",
+			expectedErr: "<interactive>:11:12: chdir expects a string, but a ListType was provided",
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -17,7 +17,7 @@ import (
 
 type execTestCase struct {
 	desc           string
-	execStr        string
+	code           string
 	expectedStdout string
 	expectedStderr string
 	expectedErr    string
@@ -93,7 +93,7 @@ func testShellExec(t *testing.T, shell *Shell, testcase execTestCase) {
 	shell.SetStderr(&berr)
 	shell.SetStdout(&bout)
 
-	err := shell.Exec(testcase.desc, testcase.execStr)
+	err := shell.Exec(testcase.desc, testcase.code)
 	if err != nil {
 		if err.Error() != testcase.expectedErr {
 			t.Errorf("[%s] Error differs: Expected '%s' but got '%s'",
@@ -193,35 +193,35 @@ func TestExecuteCommand(t *testing.T) {
 	for _, test := range []execTestCase{
 		{
 			desc:           "command failed",
-			execStr:        `non-existing-program`,
+			code:           `non-existing-program`,
 			expectedStdout: "",
 			expectedStderr: "",
 			expectedErr:    `exec: "non-existing-program": executable file not found in $PATH`,
 		},
 		{
 			desc:           "err ignored",
-			execStr:        `-non-existing-program`,
+			code:           `-non-existing-program`,
 			expectedStdout: "",
 			expectedStderr: "",
 			expectedErr:    "",
 		},
 		{
 			desc:           "hello world",
-			execStr:        "echo -n hello world",
+			code:           "echo -n hello world",
 			expectedStdout: "hello world",
 			expectedStderr: "",
 			expectedErr:    "",
 		},
 		{
 			desc:           "cmd with concat",
-			execStr:        `echo -n "hello " + "world"`,
+			code:           `echo -n "hello " + "world"`,
 			expectedStdout: "hello world",
 			expectedStderr: "",
 			expectedErr:    "",
 		},
 		{
 			desc: "local command",
-			execStr: `echopath <= which echo
+			code: `echopath <= which echo
 path <= dirname $echopath
 chdir($path)
 ./echo -n hello`,
@@ -301,7 +301,7 @@ func TestExecuteMultipleAssignment(t *testing.T) {
 	for _, test := range []execTestCase{
 		{
 			desc: "multiple assignment",
-			execStr: `_1, _2 = "1", "2"
+			code: `_1, _2 = "1", "2"
 				echo -n $_1 $_2`,
 			expectedStdout: "1 2",
 			expectedStderr: "",
@@ -309,7 +309,7 @@ func TestExecuteMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "multiple assignment",
-			execStr: `_1, _2, _3 = "1", "2", "3"
+			code: `_1, _2, _3 = "1", "2", "3"
 				echo -n $_1 $_2 $_3`,
 			expectedStdout: "1 2 3",
 			expectedStderr: "",
@@ -317,7 +317,7 @@ func TestExecuteMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "multiple assignment",
-			execStr: `_1, _2 = (), ()
+			code: `_1, _2 = (), ()
 				echo -n $_1 $_2`,
 			expectedStdout: "",
 			expectedStderr: "",
@@ -325,7 +325,7 @@ func TestExecuteMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "multiple assignment",
-			execStr: `_1, _2 = (1 2 3 4 5), (6 7 8 9 10)
+			code: `_1, _2 = (1 2 3 4 5), (6 7 8 9 10)
 				echo -n $_1 $_2`,
 			expectedStdout: "1 2 3 4 5 6 7 8 9 10",
 			expectedStderr: "",
@@ -333,7 +333,7 @@ func TestExecuteMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "multiple assignment",
-			execStr: `_1, _2, _3, _4, _5, _6, _7, _8, _9, _10 = "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
+			code: `_1, _2, _3, _4, _5, _6, _7, _8, _9, _10 = "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
 				echo -n $_1 $_2 $_3 $_4 $_5 $_6 $_7 $_8 $_9 $_10`,
 			expectedStdout: "1 2 3 4 5 6 7 8 9 10",
 			expectedStderr: "",
@@ -341,7 +341,7 @@ func TestExecuteMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "multiple assignment",
-			execStr: `_1, _2 = (a b c), "d"
+			code: `_1, _2 = (a b c), "d"
 				echo -n $_1 $_2`,
 			expectedStdout: "a b c d",
 			expectedStderr: "",
@@ -349,7 +349,7 @@ func TestExecuteMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "multiple assignment",
-			execStr: `fn a() { echo -n "a" }
+			code: `fn a() { echo -n "a" }
 				  fn b() { echo -n "b" }
 				  _a, _b = $a, $b
 				  $_a(); $_b()`,
@@ -459,7 +459,7 @@ func TestExecuteCmdMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "list assignment",
-			execStr: `l = (0 1 2 3)
+			code: `l = (0 1 2 3)
                          a = "2"
                          l[$a], err <= echo -n "666"
                          if $err == "0" {
@@ -471,14 +471,14 @@ func TestExecuteCmdMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc:           "cmd assignment works with 1 or 2 variables",
-			execStr:        "out, err1, err2 <= echo something",
+			code:           "out, err1, err2 <= echo something",
 			expectedStdout: "",
 			expectedStderr: "",
 			expectedErr:    "<interactive>:1:0: multiple assignment of commands requires two variable names, but got 3",
 		},
 		{
 			desc: "ignore error",
-			execStr: `out, _ <= cat /file-not-found/test >[2=]
+			code: `out, _ <= cat /file-not-found/test >[2=]
 					echo -n $out`,
 			expectedStdout: "",
 			expectedStderr: "",
@@ -486,7 +486,7 @@ func TestExecuteCmdMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "exec without '-' and getting status still fails",
-			execStr: `out <= cat /file-not-found/test >[2=]
+			code: `out <= cat /file-not-found/test >[2=]
 					echo $out`,
 			expectedStdout: "",
 			expectedStderr: "",
@@ -494,7 +494,7 @@ func TestExecuteCmdMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "check status",
-			execStr: `out, status <= cat /file-not-found/test >[2=]
+			code: `out, status <= cat /file-not-found/test >[2=]
 					if $status == "0" {
 						echo -n "must fail.. sniff"
 					} else if $status == "1" {
@@ -509,7 +509,7 @@ func TestExecuteCmdMultipleAssignment(t *testing.T) {
 		},
 		{
 			desc: "multiple return in functions",
-			execStr: `fn fun() {
+			code: `fn fun() {
 					return "1", "2"
 				}
 
@@ -1195,28 +1195,47 @@ func TestNonInteractive(t *testing.T) {
 }
 
 func TestExecuteBindFn(t *testing.T) {
+
 	for _, test := range []execTestCase{
 		{
-			"test bindfn",
-			`
-        fn cd(path) {
-                echo "override builtin cd"
-        }
+			desc: "test bindfn",
+			code: `
+				fn cd(path) {
+					echo "override builtin cd"
+				}
 
-        bindfn cd cd
-        cd`,
-			"override builtin cd\n", "", "",
+				bindfn cd cd
+				cd
+			`,
+			expectedStdout: "override builtin cd\n",
 		},
 		{
-			"test bindfn args",
-			`
-        fn foo(line) {
-                echo $line
-        }
+			desc: "test bindfn vargs",
+			code: `
+				fn echoargs(args...) {
+					for a in $args {
+						echo $a
+					}
+				}
 
-        bindfn foo bar
-        bar test test`,
-			"", "", "<interactive>:7:8: Too much arguments for function 'foo'. It expects 1 args, but given 2. Arguments: [\"test\" \"test\"]",
+				bindfn echoargs echoargs
+				echoargs
+				echoargs "a"
+				echoargs "b" "c"
+			`,
+			expectedStdout: "a\nb\nc\n",
+		},
+		{
+			desc: "test bindfn args",
+			code: `
+				fn foo(line) {
+					echo $line
+				}
+
+				bindfn foo bar
+				bar test test
+			`,
+			expectedErr: "<interactive>:7:4: Too much arguments for function 'foo'. It expects 1 args, but given 2. Arguments: [\"test\" \"test\"]",
 		},
 	} {
 		testInteractiveExec(t, test)
@@ -2371,7 +2390,7 @@ func TestExecuteVariadicFn(t *testing.T) {
 	for _, test := range []execTestCase{
 		{
 			desc: "println",
-			execStr: `fn println(fmt, arg...) {
+			code: `fn println(fmt, arg...) {
 	print($fmt+"\n", $arg...)
 }
 println("%s %s", "test", "test")`,
@@ -2381,7 +2400,7 @@ println("%s %s", "test", "test")`,
 		},
 		{
 			desc: "lots of args",
-			execStr: `fn println(fmt, arg...) {
+			code: `fn println(fmt, arg...) {
 	print($fmt+"\n", $arg...)
 }
 println("%s%s%s%s%s%s%s%s%s%s", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10")`,
@@ -2391,7 +2410,7 @@ println("%s%s%s%s%s%s%s%s%s%s", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10
 		},
 		{
 			desc: "passing list to var arg fn",
-			execStr: `fn puts(arg...) { for a in $arg { echo $a } }
+			code: `fn puts(arg...) { for a in $arg { echo $a } }
 				a = ("1" "2" "3" "4" "5")
 				puts($a...)`,
 			expectedErr:    "",
@@ -2400,7 +2419,7 @@ println("%s%s%s%s%s%s%s%s%s%s", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10
 		},
 		{
 			desc: "passing empty list to var arg fn",
-			execStr: `fn puts(arg...) { for a in $arg { echo $a } }
+			code: `fn puts(arg...) { for a in $arg { echo $a } }
 				a = ()
 				puts($a...)`,
 			expectedErr:    "",
@@ -2409,23 +2428,23 @@ println("%s%s%s%s%s%s%s%s%s%s", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10
 		},
 		{
 			desc: "... expansion",
-			execStr: `args = ("plan9" "from" "outer" "space")
+			code: `args = ("plan9" "from" "outer" "space")
 print("%s %s %s %s", $args...)`,
 			expectedStdout: "plan9 from outer space",
 		},
 		{
 			desc:           "literal ... expansion",
-			execStr:        `print("%s:%s:%s", ("a" "b" "c")...)`,
+			code:           `print("%s:%s:%s", ("a" "b" "c")...)`,
 			expectedStdout: "a:b:c",
 		},
 		{
 			desc:        "varargs only as last argument",
-			execStr:     `fn println(arg..., fmt) {}`,
+			code:        `fn println(arg..., fmt) {}`,
 			expectedErr: "<interactive>:1:11: Vararg 'arg...' isn't the last argument",
 		},
 		{
 			desc: "variadic argument are optional",
-			execStr: `fn println(b...) {
+			code: `fn println(b...) {
 	for v in $b {
 		print($v)
 	}
@@ -2436,7 +2455,7 @@ println()`,
 		},
 		{
 			desc: "the first argument isn't optional",
-			execStr: `fn a(b, c...) {
+			code: `fn a(b, c...) {
     print($b, $c...)
 }
 a("test")`,
@@ -2444,7 +2463,7 @@ a("test")`,
 		},
 		{
 			desc: "the first argument isn't optional",
-			execStr: `fn a(b, c...) {
+			code: `fn a(b, c...) {
     print($b, $c...)
 }
 a()`,


### PR DESCRIPTION
Fix bindfn vargs to work properly, there was some validations that where unecessary so I removed them and fixed the cd builtin bindfn so it keeps working. Not sure if it was the best course of action but it seemed that the duplicated validations of function arity where not the way to go (that is already handled on the function dispatch mechanism).

Also changed travis to only work with Go >= 1.9 since the t.Helper() thing was really helpfull debugging test failures =)

Anyway, nothing better to start an year than crappy code

![happy new year](http://www.garancedore.fr/wp-content/uploads/2013/05/leo-dicaprio-gatsby.jpg)