### PR TITLE
Add second return to glob to indicate pattern error

### DIFF
--- a/internal/sh/builtin/glob.go
+++ b/internal/sh/builtin/glob.go
@@ -1,6 +1,7 @@
 package builtin
 
 import (
+	"fmt"
 	"io"
 	"path/filepath"
 
@@ -26,12 +27,15 @@ func (g *globFn) Run(in io.Reader, out io.Writer, e io.Writer) ([]sh.Obj, error)
 	listobjs := []sh.Obj{}
 	matches, err := filepath.Glob(g.pattern)
 	if err != nil {
-		return nil, errors.NewError("glob:error: %q", err)
+		return []sh.Obj{
+			sh.NewListObj([]sh.Obj{}),
+			sh.NewStrObj(fmt.Sprintf("glob:error: %q", err)),
+		}, nil
 	}
 	for _, match := range matches {
 		listobjs = append(listobjs, sh.NewStrObj(match))
 	}
-	return []sh.Obj{sh.NewListObj(listobjs)}, nil
+	return []sh.Obj{sh.NewListObj(listobjs), sh.NewStrObj("")}, nil
 }
 
 func (g *globFn) SetArgs(args []sh.Obj) error {

--- a/internal/sh/builtin/glob_test.go
+++ b/internal/sh/builtin/glob_test.go
@@ -35,11 +35,13 @@ func TestGlobNoResult(t *testing.T) {
 	pattern := dir + "/*.la"
 
 	out := execSuccess(t, fmt.Sprintf(`
-		res <= glob("%s")
+		res, err <= glob("%s")
 		print($res)
+		print($err)
+		print(len($res))
 	`, pattern))
 
-	if out != "" {
+	if out != "0" {
 		t.Fatalf("expected no results, got: %q", out)
 	}
 }
@@ -53,8 +55,9 @@ func TestGlobOneResult(t *testing.T) {
 	pattern := dir + "/*.go"
 
 	out := execSuccess(t, fmt.Sprintf(`
-		res <= glob("%s")
+		res, err <= glob("%s")
 		print($res)
+		print($err)
 	`, pattern))
 
 	if out != filename {
@@ -75,8 +78,9 @@ func TestGlobMultipleResults(t *testing.T) {
 	pattern := dir + "/*.h"
 
 	out := execSuccess(t, fmt.Sprintf(`
-		res <= glob("%s")
+		res, err <= glob("%s")
 		print($res)
+		print($err)
 	`, pattern))
 
 	res := strings.Split(out, " ")
@@ -101,24 +105,53 @@ func TestGlobMultipleResults(t *testing.T) {
 	}
 }
 
-func TestGlobNoParamError(t *testing.T) {
-	execFailure(t, `
-		res <= glob()
-		print($res)
-	`)
-}
-
-func TestGlobWrongType(t *testing.T) {
-	execFailure(t, `
-		param = ("hi")
-		res <= glob($param)
-		print($res)
-	`)
-}
-
 func TestGlobInvalidPatternError(t *testing.T) {
-	execFailure(t, `
-		res <= glob("*[.go")
+	out := execSuccess(t, `
+		res, err <= glob("*[.go")
 		print($res)
+		if $err != "" {
+			print("got error")
+		}
 	`)
+
+	if out != "got error" {
+		t.Fatalf("expected error message on glob, got nothing, output[%s]", out)
+	}
+}
+
+func TestFatalFailure(t *testing.T) {
+	type tcase struct {
+		name string
+		code string
+	}
+	cases := []tcase{
+		tcase{
+			name: "noParam",
+			code: `
+				res <= glob()
+				print($res)
+			`,
+		},
+		tcase{
+			name: "multipleParams",
+			code: `
+				res <= glob("/a/*", "/b/*")
+				print($res)
+			`,
+		},
+		tcase{
+			name: "wrongType",
+			code: `
+				param = ("hi")
+				res <= glob($param)
+				print($res)
+			`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			execFailure(t, c.code)
+		})
+	}
 }


### PR DESCRIPTION
The current glob implementation generates a fatal error if the pattern passed is invalid. This is not a great idea since glob is a builtin and taking the decision to abort or not from the programmer for such an essencial/basic function does not seem very smart.

I realized that when I was trying to generalize a function to expand args with glob, a very easy solution for me is to try to glob all parameters, the ones that succeed I use the results, the ones that don't I use the original parameter. The only problem is that some parameters will force my scripts to abort =( (for something that is a recoverable error).