### PR TITLE
add common cfg into tests pkg and simplify setup of tests

### DIFF
--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/NeowayLabs/nash/sh"
+	"github.com/NeowayLabs/nash/tests"
 )
 
 type execTestCase struct {
@@ -29,27 +30,14 @@ type fixture struct {
 }
 
 func setup(t *testing.T) (fixture, func()) {
-	gopath := os.Getenv("GOPATH")
-
-	if gopath == "" {
-		t.Fatal("Please, run tests from inside GOPATH")
-	}
-
-	testDir := gopath + "/src/github.com/NeowayLabs/nash/" + "testfiles"
-	nashdPath := gopath + "/src/github.com/NeowayLabs/nash/cmd/nash/nash"
-
-	if _, err := os.Stat(nashdPath); err != nil {
-		t.Fatal("Please, run make build before running tests")
-	}
-
 	err := os.Setenv("NASHPATH", "/tmp/.nash")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	return fixture{
-			dir:       testDir,
-			nashdPath: nashdPath,
+			dir:       tests.Testdir,
+			nashdPath: tests.Nashcmd,
 		}, func() {
 			err := os.Unsetenv("NASHPATH")
 			if err != nil {

--- a/nash_test.go
+++ b/nash_test.go
@@ -6,32 +6,14 @@ import (
 	"testing"
 
 	"github.com/NeowayLabs/nash/sh"
+	"github.com/NeowayLabs/nash/tests"
 )
 
 // only testing the public API
 // bypass to internal sh.Shell
 
-var (
-	gopath, testDir, nashdPath string
-)
-
-func init() {
-	gopath = os.Getenv("GOPATH")
-
-	if gopath == "" {
-		panic("Please, run tests from inside GOPATH")
-	}
-
-	testDir = gopath + "/src/github.com/NeowayLabs/nash/" + "testfiles"
-	nashdPath = gopath + "/src/github.com/NeowayLabs/nash/cmd/nash/nash"
-
-	if _, err := os.Stat(nashdPath); err != nil {
-		panic("Please, run make build before running tests")
-	}
-}
-
 func TestExecuteFile(t *testing.T) {
-	testfile := testDir + "/ex1.sh"
+	testfile := tests.Testdir + "/ex1.sh"
 
 	var out bytes.Buffer
 
@@ -42,7 +24,7 @@ func TestExecuteFile(t *testing.T) {
 		return
 	}
 
-	shell.SetNashdPath(nashdPath)
+	shell.SetNashdPath(tests.Nashcmd)
 	shell.SetStdout(&out)
 	shell.SetStderr(os.Stderr)
 	shell.SetStdin(os.Stdin)

--- a/spec_test.go
+++ b/spec_test.go
@@ -3,32 +3,30 @@ package nash
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/NeowayLabs/nash/tests"
 	"golang.org/x/exp/ebnf"
 )
 
 func TestSpecificationIsSane(t *testing.T) {
-	filename := os.Getenv("GOPATH") + "/src/github.com/NeowayLabs/nash/spec.ebnf"
+	filename := filepath.Join(tests.Gopath, "src", "github.com",
+		"NeowayLabs", "nash", "spec.ebnf")
 	content, err := ioutil.ReadFile(filename)
-
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
 	buf := bytes.NewBuffer(content)
-
 	grammar, err := ebnf.Parse(filename, buf)
-
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
 	err = ebnf.Verify(grammar, "program")
-
 	if err != nil {
 		t.Error(err)
 		return

--- a/tests/cfg.go
+++ b/tests/cfg.go
@@ -1,3 +1,62 @@
 package tests
 
-const nashcmd = "../cmd/nash/nash"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	// Nashcmd is the nash's absolute binary path in source
+	Nashcmd string
+	// Testdir is the test assets directory
+	Testdir string
+	Gopath  string
+)
+
+func getGopath() (string, error) {
+	gopathenv := os.Getenv("GOPATH")
+	if gopathenv != "" {
+		return gopathenv, nil
+	}
+
+	usr, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user's home directory: %s", err)
+	}
+
+	gopathhome := filepath.Join(usr.HomeDir, "go")
+	if _, err := os.Stat(gopathhome); err != nil {
+		return "", errors.New("gopath not found")
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get working directory: %s", err)
+	}
+
+	if !strings.HasPrefix(wd, gopathhome) {
+		return "", errors.New("Run tests require code inside gopath")
+	}
+	return gopathhome, nil
+}
+
+func init() {
+	gopath, err := getGopath()
+	if err != nil {
+		panic(err)
+	}
+
+	Gopath = gopath
+	Testdir = filepath.Join(Gopath, "src", "github.com",
+		"NeowayLabs", "nash", "testfiles")
+	Nashcmd = filepath.Join(Gopath, "src", "github.com",
+		"NeowayLabs", "nash", "cmd", "nash", "nash")
+
+	if _, err := os.Stat(Nashcmd); err != nil {
+		panic("Please, run make build before running tests")
+	}
+}

--- a/tests/internal/tester/tester.go
+++ b/tests/internal/tester/tester.go
@@ -18,7 +18,6 @@ type TestCase struct {
 }
 
 func Run(t *testing.T, nashcmd string, cases ...TestCase) {
-
 	for _, tcase := range cases {
 		t.Run(tcase.Name, func(t *testing.T) {
 			stdout, stderr, err := sh.Exec(t, nashcmd, tcase.ScriptCode)

--- a/tests/listindex_test.go
+++ b/tests/listindex_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestListIndexing(t *testing.T) {
-	tester.Run(t, nashcmd,
+	tester.Run(t, Nashcmd,
 		tester.TestCase{
 			Name: "PositionalAccess",
 			ScriptCode: `

--- a/tests/stringindex_test.go
+++ b/tests/stringindex_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestStringIndexing(t *testing.T) {
-	tester.Run(t, nashcmd,
+	tester.Run(t, Nashcmd,
 		tester.TestCase{
 			Name: "IterateEmpty",
 			ScriptCode: `
@@ -41,7 +41,7 @@ func TestStringIndexing(t *testing.T) {
 	)
 }
 func TestStringIndexingASCII(t *testing.T) {
-	tester.Run(t, nashcmd,
+	tester.Run(t, Nashcmd,
 		tester.TestCase{Name: "PositionalAccess",
 			ScriptCode: `
 				a = "12"
@@ -91,7 +91,7 @@ func TestStringIndexingASCII(t *testing.T) {
 }
 
 func TestStringIndexingNonASCII(t *testing.T) {
-	tester.Run(t, nashcmd,
+	tester.Run(t, Nashcmd,
 		tester.TestCase{Name: "PositionalAccess",
 			ScriptCode: `
 				a = "⌘⌘"


### PR DESCRIPTION
@katcipis I know the tests package are there for blackbox tests, but I think it's a good place to put some of the common/util logics that were currently repeated in test code (like getting gopath, testdir, nashcmd).

What do you think?

Closes #255 