### PR TITLE
Add strings to stdbin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist
 *.exe
 stdbin/mkdir/mkdir
 stdbin/pwd/pwd
+stdbin/strings/strings
+

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build:
 NASHPATH=$(HOME)/nash
 NASHROOT=$(HOME)/nashroot
 
+# FIXME: binaries install do not work on windows this way (the .exe)
 install: build
 	@echo
 	@echo "Installing nash at: "$(NASHROOT)
@@ -27,6 +28,7 @@ install: build
 	cp -pr ./stdlib $(NASHROOT)/stdlib
 	cp -pr ./stdbin/mkdir/mkdir $(NASHROOT)/bin/mkdir
 	cp -pr ./stdbin/pwd/pwd $(NASHROOT)/bin/pwd
+	cp -pr ./stdbin/strings/strings $(NASHROOT)/bin/strings
 
 docsdeps:
 	go get github.com/katcipis/mdtoc

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ build:
 	cd cmd/nashfmt && go build $(buildargs) 
 	cd stdbin/mkdir && go build $(buildargs)
 	cd stdbin/pwd && go build $(buildargs)
+	cd stdbin/strings && go build $(buildargs)
 
 NASHPATH=$(HOME)/nash
 NASHROOT=$(HOME)/nashroot

--- a/stdbin/strings/main.go
+++ b/stdbin/strings/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 
-	const defaultMinTextSize = 6
+	const defaultMinTextSize = 4
 	var minTextSize uint
 
 	flag.UintVar(
@@ -23,7 +23,7 @@ func main() {
 		fmt.Println(scanner.Text())
 	}
 	if scanner.Err() != nil {
-		fmt.Printf("error: %s", scanner.Err())
+		fmt.Fprintf(os.Stderr, "error: %s", scanner.Err())
 		os.Exit(1)
 	}
 }

--- a/stdbin/strings/main.go
+++ b/stdbin/strings/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+
+	const defaultMinTextSize = 6
+	var minTextSize uint
+
+	flag.UintVar(
+		&minTextSize,
+		"s",
+		defaultMinTextSize,
+		"the minimum size in runes to characterize as a text",
+	)
+
+	scanner := Do(os.Stdin, minTextSize)
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
+	}
+	if scanner.Err() != nil {
+		fmt.Printf("error: %s", scanner.Err())
+		os.Exit(1)
+	}
+}

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -77,11 +77,20 @@ func searchstrings(input io.Reader, minTextSize uint, output *io.PipeWriter) {
 }
 
 func parseNonASCII(input io.Reader, first byte) (string, bool) {
-	// TODO: how to test when seems like a rune but it is not
 	data := make([]byte, 1)
-	// TODO: handle io errors during rune parsing
-	input.Read(data)
-	// TODO: not handling invalid and other sizes
-	possibleWord := string([]byte{first, data[0]})
-	return possibleWord, utf8.ValidString(possibleWord)
+	buffer := []byte{first}
+
+	// TODO: test if second/other bytes are not valid continuation of
+	// an UTF-8 bigger character but are valid single byte UTF-8
+	for i := 0; i < 3; i++ {
+		// TODO: handle io errors during rune parsing
+		input.Read(data)
+		buffer = append(buffer, data[0])
+		possibleWord := string(buffer)
+		if utf8.ValidString(possibleWord) {
+			return possibleWord, true
+		}
+	}
+
+	return "", false
 }

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -2,9 +2,39 @@ package strings
 
 import (
 	"bufio"
+	"fmt"
 	"io"
+	"unicode/utf8"
 )
 
-func Do(input io.Reader) *bufio.Scanner {
-	return nil
+func Do(input io.Reader, minTextSize int) *bufio.Scanner {
+	outputReader, outputWriter := io.Pipe()
+	go searchstrings(input, minTextSize, outputWriter)
+	return bufio.NewScanner(outputReader)
+}
+
+func searchstrings(input io.Reader, minTextSize int, output *io.PipeWriter) {
+
+	// TODO: This still don't cover utf-8 corner cases (possibly a lot of them)
+	// Also not respecting minTextSize...yet =)
+	data := make([]byte, 1)
+	for {
+		_, err := input.Read(data)
+		if err == io.EOF {
+			output.Close()
+			return
+		}
+		if err != nil {
+			output.CloseWithError(err)
+			return
+		}
+
+		if word := string(data); utf8.ValidString(word) {
+			_, err = output.Write(data)
+			if err != nil {
+				output.CloseWithError(fmt.Errorf("strings:fatal error[%s] writing data\n", err))
+				return
+			}
+		}
+	}
 }

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -17,24 +17,50 @@ func searchstrings(input io.Reader, minTextSize int, output *io.PipeWriter) {
 
 	// TODO: This still don't cover utf-8 corner cases (possibly a lot of them)
 	// Also not respecting minTextSize...yet =)
+
+	newline := []byte("\n")
+	buffer := []byte{}
+
+	writeOnBuffer := func(d []byte) {
+		buffer = append(buffer, d...)
+	}
+
+	flushBuffer := func() {
+		if len(buffer) == 0 {
+			return
+		}
+		buffer = append(buffer, newline...)
+		n, err := output.Write(buffer)
+		if n != len(buffer) {
+			output.CloseWithError(fmt.Errorf("strings:fatal wrote[%d] bytes wanted[%d]\n", n, len(buffer)))
+			return
+		}
+		if err != nil {
+			output.CloseWithError(fmt.Errorf("strings:fatal error[%s] writing data\n", err))
+			return
+		}
+		buffer = nil
+	}
+
 	data := make([]byte, 1)
 	for {
+		// WHY: Don't see the point of checking N when reading a single byte
 		_, err := input.Read(data)
 		if err == io.EOF {
+			flushBuffer()
 			output.Close()
 			return
 		}
 		if err != nil {
+			flushBuffer()
 			output.CloseWithError(err)
 			return
 		}
 
 		if word := string(data); utf8.ValidString(word) {
-			_, err = output.Write(data)
-			if err != nil {
-				output.CloseWithError(fmt.Errorf("strings:fatal error[%s] writing data\n", err))
-				return
-			}
+			writeOnBuffer(data)
+		} else {
+			flushBuffer()
 		}
 	}
 }

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -16,7 +16,6 @@ func Do(input io.Reader, minTextSize int) *bufio.Scanner {
 func searchstrings(input io.Reader, minTextSize int, output *io.PipeWriter) {
 
 	// TODO: This still don't cover utf-8 corner cases (possibly a lot of them)
-	// Also not respecting minTextSize...yet =)
 
 	newline := []byte("\n")
 	buffer := []byte{}
@@ -27,6 +26,11 @@ func searchstrings(input io.Reader, minTextSize int, output *io.PipeWriter) {
 
 	flushBuffer := func() {
 		if len(buffer) == 0 {
+			return
+		}
+		// TODO test and utf-8 chars
+		if len(buffer) < minTextSize {
+			buffer = nil
 			return
 		}
 		buffer = append(buffer, newline...)

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -7,13 +7,13 @@ import (
 	"unicode/utf8"
 )
 
-func Do(input io.Reader, minTextSize int) *bufio.Scanner {
+func Do(input io.Reader, minTextSize uint) *bufio.Scanner {
 	outputReader, outputWriter := io.Pipe()
 	go searchstrings(input, minTextSize, outputWriter)
 	return bufio.NewScanner(outputReader)
 }
 
-func searchstrings(input io.Reader, minTextSize int, output *io.PipeWriter) {
+func searchstrings(input io.Reader, minTextSize uint, output *io.PipeWriter) {
 
 	// TODO: This still don't cover utf-8 corner cases (possibly a lot of them)
 
@@ -29,7 +29,7 @@ func searchstrings(input io.Reader, minTextSize int, output *io.PipeWriter) {
 			return
 		}
 		// TODO test and utf-8 chars
-		if len(buffer) < minTextSize {
+		if uint(len(buffer)) < minTextSize {
 			buffer = nil
 			return
 		}

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -115,6 +115,11 @@ func (w *wordSearcher) nextRune(b byte) ([]byte, bool) {
 
 	const maxUTFSize = 4
 
+	if b == 0 {
+		w.resetRuneSearch()
+		return w.flushBuffer()
+	}
+
 	if word := string([]byte{b}); utf8.ValidString(word) {
 		w.resetRuneSearch()
 		data, ok := w.flushBuffer()
@@ -198,6 +203,9 @@ func (w *wordSearcher) flushBuffer() ([]byte, bool) {
 }
 
 func bytetype(b byte) byteType {
+	if b == 0 {
+		return binaryType
+	}
 	if word := string([]byte{b}); utf8.ValidString(word) {
 		return asciiType
 	}

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -47,25 +47,46 @@ func searchstrings(input io.Reader, minTextSize uint, output *io.PipeWriter) {
 		buffer = nil
 	}
 
-	data := make([]byte, 1)
-	for {
-		// WHY: Don't see the point of checking N when reading a single byte
-		_, err := input.Read(data)
+	handleIOError := func(err error) bool {
 		if err == io.EOF {
 			flushBuffer()
 			output.Close()
-			return
+			return true
 		}
 		if err != nil {
 			flushBuffer()
 			output.CloseWithError(err)
-			return
+			return true
+		}
+		return false
+	}
+
+	data := make([]byte, 1)
+	for {
+		// WHY: Don't see the point of checking N when reading a single byte
+		n, err := input.Read(data)
+
+		if n <= 0 {
+			if handleIOError(err) {
+				return
+			}
+			// WHY:
+			// Implementations of Read are discouraged from
+			// returning a zero byte count with a nil error,
+			// except when len(p) == 0.
+			// Callers should treat a return of 0 and nil as
+			// indicating that nothing happened; in particular it
+			// does not indicate EOF.
+			continue
 		}
 
 		if word := string(data); utf8.ValidString(word) {
 			writeOnBuffer(word)
 		} else if utf8.RuneStart(data[0]) {
-			if word, ok := searchNonASCII(input, data[0]); ok {
+			if word, flush, ok := searchNonASCII(input, data[0]); ok {
+				if flush {
+					flushBuffer()
+				}
 				writeOnBuffer(word)
 			} else {
 				flushBuffer()
@@ -73,10 +94,14 @@ func searchstrings(input io.Reader, minTextSize uint, output *io.PipeWriter) {
 		} else {
 			flushBuffer()
 		}
+
+		if handleIOError(err) {
+			return
+		}
 	}
 }
 
-func searchNonASCII(input io.Reader, first byte) (string, bool) {
+func searchNonASCII(input io.Reader, first byte) (string, bool, bool) {
 	data := make([]byte, 1)
 	buffer := []byte{first}
 	// WHY: We already have the first byte, 3 missing
@@ -91,14 +116,14 @@ func searchNonASCII(input io.Reader, first byte) (string, bool) {
 		if word := string(data); utf8.ValidString(word) {
 			// WHY: Valid ASCII range after something that looked
 			// like a possible char outsize ASCII
-			return word, true
+			return word, true, true
 		}
 		buffer = append(buffer, data[0])
 		possibleWord := string(buffer)
 		if utf8.ValidString(possibleWord) {
-			return possibleWord, true
+			return possibleWord, false, true
 		}
 	}
 
-	return "", false
+	return "", false, false
 }

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -108,10 +108,7 @@ func searchNonASCII(input io.Reader, first byte) (string, bool, bool) {
 	missingCharsForUTF := 3
 
 	for i := 0; i < missingCharsForUTF; i++ {
-		// WHY: ignoring read errors here will cause us to
-		// go back to the main search loop and eventually
-		// will call Read again which will fail again.
-		// Perhaps not a very good idea.
+		// TODO: Test Read errors here
 		input.Read(data)
 		if word := string(data); utf8.ValidString(word) {
 			// WHY: Valid ASCII range after something that looked

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -1,4 +1,4 @@
-package strings
+package main
 
 import (
 	"bufio"

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -1,0 +1,10 @@
+package strings
+
+import (
+	"bufio"
+	"io"
+)
+
+func Do(input io.Reader) *bufio.Scanner {
+	return nil
+}

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -112,17 +112,16 @@ func (w *wordSearcher) nextRune(b byte) ([]byte, bool) {
 
 	if word := string([]byte{b}); utf8.ValidString(word) {
 		w.resetRuneSearch()
-		text, ok := w.flushBuffer()
+		data, ok := w.flushBuffer()
 		w.writeOnBuffer(b)
-		return text, ok
+		return data, ok
 	}
 
 	if utf8.RuneStart(b) {
-		// TODO: write test to exercise flush of previous text on this
-		// case since what looked like a rune was actually binary data.
 		w.resetRuneSearch()
+		data, ok := w.flushBuffer()
 		w.startRuneSearch(b)
-		return nil, false
+		return data, ok
 	}
 
 	w.writeOnPossibleRune(b)

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -82,11 +82,14 @@ func parseNonASCII(input io.Reader, first byte) (string, bool) {
 	// WHY: We already have the first byte, 3 missing
 	missingCharsForUTF := 3
 
-	// TODO: test if second/other bytes are not valid continuation of
-	// an UTF-8 bigger character but are valid single byte UTF-8
 	for i := 0; i < missingCharsForUTF; i++ {
 		// TODO: handle io errors during rune parsing
 		input.Read(data)
+		if word := string(data); utf8.ValidString(word) {
+			// WHY: Valid ASCII range after something that looked
+			// like a possible char outsize ASCII
+			return word, true
+		}
 		buffer = append(buffer, data[0])
 		possibleWord := string(buffer)
 		if utf8.ValidString(possibleWord) {

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -79,10 +79,12 @@ func searchstrings(input io.Reader, minTextSize uint, output *io.PipeWriter) {
 func parseNonASCII(input io.Reader, first byte) (string, bool) {
 	data := make([]byte, 1)
 	buffer := []byte{first}
+	// WHY: We already have the first byte, 3 missing
+	missingCharsForUTF := 3
 
 	// TODO: test if second/other bytes are not valid continuation of
 	// an UTF-8 bigger character but are valid single byte UTF-8
-	for i := 0; i < 3; i++ {
+	for i := 0; i < missingCharsForUTF; i++ {
 		// TODO: handle io errors during rune parsing
 		input.Read(data)
 		buffer = append(buffer, data[0])

--- a/stdbin/strings/strings.go
+++ b/stdbin/strings/strings.go
@@ -10,7 +10,12 @@ import (
 func Do(input io.Reader, minTextSize uint) *bufio.Scanner {
 	outputReader, outputWriter := io.Pipe()
 	go searchstrings(input, minTextSize, outputWriter)
-	return bufio.NewScanner(outputReader)
+	scanner := bufio.NewScanner(outputReader)
+
+	const maxBufferSize = 1024 * 1024
+	b := make([]byte, maxBufferSize)
+	scanner.Buffer(b, maxBufferSize)
+	return scanner
 }
 
 func searchstrings(input io.Reader, minTextSize uint, output *io.PipeWriter) {

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -298,6 +298,37 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"v", "λ"},
 		},
+		{
+			name:        "ASCIISplittedByZero",
+			minWordSize: 1,
+			input: func([]byte) []byte {
+				return []byte{'k', 0, 'n', 0, 'v'}
+			},
+			output: []string{"k", "n", "v"},
+		},
+		{
+			name:        "RunesSplittedByZero",
+			minWordSize: 1,
+			input: func([]byte) []byte {
+				i := []byte("λ")
+				i = append(i, 0)
+				i = append(i, []byte("λ")...)
+				return i
+			},
+			output: []string{"λ", "λ"},
+		},
+		{
+			name:        "ASCIIAndRunesSplittedByZero",
+			minWordSize: 1,
+			input: func([]byte) []byte {
+				i := []byte("λ")
+				i = append(i, 0)
+				i = append(i, 's')
+				i = append(i, []byte("λ")...)
+				return i
+			},
+			output: []string{"λ", "s", "λ"},
+		},
 	}
 
 	minBinChunkSize := 1
@@ -318,6 +349,7 @@ func TestStrings(t *testing.T) {
 				}
 
 				if len(lines) != len(tcase.output) {
+					t.Errorf("wanted size[%d] got size[%d]", len(tcase.output), len(lines))
 					t.Fatalf("wanted[%s] got[%s]", tcase.output, lines)
 				}
 

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -364,7 +364,7 @@ func TestStrings(t *testing.T) {
 				}
 
 				if scanner.Err() != nil {
-					t.Fatal("unexpected error[%s]", scanner.Err())
+					t.Fatalf("unexpected error[%s]", scanner.Err())
 				}
 			})
 		}

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -17,7 +17,7 @@ func TestStrings(t *testing.T) {
 
 	type testcase struct {
 		name        string
-		input       func() []byte
+		input       func([]byte) []byte
 		output      []string
 		minWordSize uint
 	}
@@ -26,8 +26,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "UTF-8With2Bytes",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte("λ"), bin...)
 			},
 			output: []string{"λ"},
@@ -35,8 +34,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "UTF-8With3Bytes",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte("€"), bin...)
 			},
 			output: []string{"€"},
@@ -44,8 +42,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "UTF-8With4Bytes",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte("𐍈"), bin...)
 			},
 			output: []string{"𐍈"},
@@ -53,8 +50,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "NonASCIIWordHasOneLessCharThanMin",
 			minWordSize: 2,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte("λ"), bin...)
 			},
 			output: []string{},
@@ -62,8 +58,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "NonASCIIWordHasMinWordSize",
 			minWordSize: 2,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte("λλ"), bin...)
 			},
 			output: []string{"λλ"},
@@ -71,8 +66,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "WordHasOneLessCharThanMin",
 			minWordSize: 2,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte("k"), bin...)
 			},
 			output: []string{},
@@ -80,8 +74,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "WordHasMinWordSize",
 			minWordSize: 2,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte("kz"), bin...)
 			},
 			output: []string{"kz"},
@@ -89,8 +82,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "WordHasOneMoreCharThanMinWordSize",
 			minWordSize: 2,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte("ktz"), bin...)
 			},
 			output: []string{"ktz"},
@@ -98,8 +90,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "StartingWithOneChar",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte("k"), bin...)
 			},
 			output: []string{"k"},
@@ -107,8 +98,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "EndWithOneChar",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append(bin, []byte("k")...)
 			},
 			output: []string{"k"},
@@ -116,8 +106,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "OneCharInTheMiddle",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				t := append(bin, []byte("k")...)
 				t = append(t, bin...)
 				return t
@@ -127,9 +116,8 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "StartingWithText",
 			minWordSize: 1,
-			input: func() []byte {
+			input: func(bin []byte) []byte {
 				expected := "textOnBeggining"
-				bin := newBinary()
 				return append([]byte(expected), bin...)
 			},
 			output: []string{"textOnBeggining"},
@@ -137,9 +125,8 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "TextOnMiddle",
 			minWordSize: 1,
-			input: func() []byte {
+			input: func(bin []byte) []byte {
 				expected := "textOnMiddle"
-				bin := newBinary()
 				return append(bin, append([]byte(expected), bin...)...)
 			},
 			output: []string{"textOnMiddle"},
@@ -147,9 +134,8 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "NonASCIITextOnMiddle",
 			minWordSize: 1,
-			input: func() []byte {
+			input: func(bin []byte) []byte {
 				expected := "λλλ"
-				bin := newBinary()
 				return append(bin, append([]byte(expected), bin...)...)
 			},
 			output: []string{"λλλ"},
@@ -157,9 +143,8 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "ASCIIAndNonASCII",
 			minWordSize: 1,
-			input: func() []byte {
+			input: func(bin []byte) []byte {
 				expected := "(define (λ (x) (+ x a)))"
-				bin := newBinary()
 				return append(bin, append([]byte(expected), bin...)...)
 			},
 			output: []string{"(define (λ (x) (+ x a)))"},
@@ -167,9 +152,8 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "TextOnEnd",
 			minWordSize: 1,
-			input: func() []byte {
+			input: func(bin []byte) []byte {
 				expected := "textOnEnd"
-				bin := newBinary()
 				return append(bin, append([]byte(expected), bin...)...)
 			},
 			output: []string{"textOnEnd"},
@@ -177,7 +161,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "JustText",
 			minWordSize: 1,
-			input: func() []byte {
+			input: func(bin []byte) []byte {
 				return []byte("justtext")
 			},
 			output: []string{"justtext"},
@@ -185,16 +169,15 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "JustBinary",
 			minWordSize: 1,
-			input: func() []byte {
-				return newBinary()
+			input: func(bin []byte) []byte {
+				return bin
 			},
 			output: []string{},
 		},
 		{
 			name:        "TextSeparatedByBinary",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				text := []byte("text")
 				t := []byte{}
 				t = append(t, bin...)
@@ -208,8 +191,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "NonASCIITextSeparatedByBinary",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				text := []byte("awesomeλ=)")
 				t := []byte{}
 				t = append(t, bin...)
@@ -223,8 +205,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "WordsAreNotAccumulativeBetweenBinData",
 			minWordSize: 2,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				t := append([]byte("k"), bin...)
 				return append(t, byte('t'))
 			},
@@ -233,8 +214,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "ASCIISeparatedByByteThatLooksLikeUTF",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte{
 					'n',
 					runestart,
@@ -246,8 +226,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "ASCIIAfterPossibleFirstByteOfUTF",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte{
 					runestart,
 					'k',
@@ -258,8 +237,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "ASCIIAfterPossibleSecondByteOfUTF",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte{
 					byte(0xE2),
 					byte(0x82),
@@ -271,8 +249,7 @@ func TestStrings(t *testing.T) {
 		{
 			name:        "ASCIIAfterPossibleThirdByteOfUTF",
 			minWordSize: 1,
-			input: func() []byte {
-				bin := newBinary()
+			input: func(bin []byte) []byte {
 				return append([]byte{
 					byte(0xF0),
 					byte(0x90),
@@ -286,7 +263,8 @@ func TestStrings(t *testing.T) {
 
 	for _, tcase := range tcases {
 		t.Run(tcase.name, func(t *testing.T) {
-			input := tcase.input()
+			bin := newBinary(10)
+			input := tcase.input(bin)
 			scanner := strings.Do(bytes.NewBuffer(input), tcase.minWordSize)
 
 			lines := []string{}
@@ -402,12 +380,11 @@ func assertScannerFails(t *testing.T, scanner *bufio.Scanner, expectedIter uint)
 	}
 }
 
-func newBinary() []byte {
+func newBinary(size uint) []byte {
 	// WHY: Starting with the most significant bit as 1 helps to test
 	// UTF-8 corner cases. Don't change this without providing
 	// testing for this. Not the best way to do this (not explicit)
 	// but it is what we have for today =).
-	size := 10
 	bin := make([]byte, size)
 	for i := 0; i < int(size); i++ {
 		bin[i] = 0xFF

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/NeowayLabs/nash/stdbin/strings"
 )
 
-// TODO: Test first byte is rune start but also a EOF, should not search for rest of the rune
-
 func TestStrings(t *testing.T) {
 
 	type testcase struct {
@@ -259,10 +257,40 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"k"},
 		},
+		{
+			name:        "AfterFalseRuneStartRuneStartOnSecondByte",
+			minWordSize: 1,
+			input: func(bin []byte) []byte {
+				i := []byte{byte(0xF0)}
+				i = append(i, []byte("λ")...)
+				return append(i, bin...)
+			},
+			output: []string{"λ"},
+		},
+		{
+			name:        "AfterFalseRuneStartRuneStartOnThirdByte",
+			minWordSize: 1,
+			input: func(bin []byte) []byte {
+				i := []byte{byte(0xF0), byte(0x90)}
+				i = append(i, []byte("λ")...)
+				return append(i, bin...)
+			},
+			output: []string{"λ"},
+		},
+		{
+			name:        "AfterFalseRuneStartRuneStartOnFourthByte",
+			minWordSize: 1,
+			input: func(bin []byte) []byte {
+				i := []byte{byte(0xF0), byte(0x90), byte(0x8D)}
+				i = append(i, []byte("λ")...)
+				return append(i, bin...)
+			},
+			output: []string{"λ"},
+		},
 	}
 
 	minBinChunkSize := 1
-	maxBinChunkSize := 1024
+	maxBinChunkSize := 128
 
 	for _, tcase := range tcases {
 		for i := minBinChunkSize; i <= maxBinChunkSize; i++ {

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -324,6 +324,7 @@ func TestStrings(t *testing.T) {
 				i := []byte("λ")
 				i = append(i, 0)
 				i = append(i, 's')
+				i = append(i, 0)
 				i = append(i, []byte("λ")...)
 				return i
 			},
@@ -385,6 +386,7 @@ func TestStringsReadErrorOnSecondByte(t *testing.T) {
 		if sentFirstByte {
 			return 0, errors.New("fake injected error")
 		}
+		d[0] = 'k'
 		sentFirstByte = true
 		return 1, nil
 	}), minWordSize)

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -1,4 +1,4 @@
-package strings_test
+package main_test
 
 import (
 	"bufio"
@@ -8,7 +8,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/NeowayLabs/nash/stdbin/strings"
+	strings "github.com/NeowayLabs/nash/stdbin/strings"
 )
 
 func TestStrings(t *testing.T) {

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -287,6 +287,17 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"λ"},
 		},
+		{
+			name:        "ASCIIFakeRuneAndThemRune",
+			minWordSize: 1,
+			input: func(bin []byte) []byte {
+				i := []byte{'v'}
+				i = append(i, byte(0xF0))
+				i = append(i, []byte("λ")...)
+				return append(i, bin...)
+			},
+			output: []string{"v", "λ"},
+		},
 	}
 
 	minBinChunkSize := 1

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/NeowayLabs/nash/stdbin/strings"
 )
 
-// TODO:
+// TODO
+
 // Test fatal error on input io.Reader
+
+// Test word size is relative to rune not bytes (practice some chinese)
 
 //func TestMinTextSizeIsAdjustable(t *testing.T) {
 //}
@@ -16,6 +19,35 @@ import (
 func TestStrings(t *testing.T) {
 
 	tcases := []testcase{
+		testcase{
+			name:        "StartingWithOneChar",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte("k"), bin...)
+			},
+			output: []string{"k"},
+		},
+		testcase{
+			name:        "EndWithOneChar",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append(bin, []byte("k")...)
+			},
+			output: []string{"k"},
+		},
+		testcase{
+			name:        "OneCharInTheMiddle",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				t := append(bin, []byte("k")...)
+				t = append(t, bin...)
+				return t
+			},
+			output: []string{"k"},
+		},
 		testcase{
 			name:        "StartingWithText",
 			minWordSize: 1,

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -2,38 +2,72 @@ package strings_test
 
 import (
 	"bytes"
+	stdstrings "strings"
 	"testing"
 
 	"github.com/NeowayLabs/nash/stdbin/strings"
 )
 
-func TestBinaryStartingWithText(t *testing.T) {
-	expected := "textOnBeggining"
-	bin := newBinary(512)
-	input := append([]byte(expected), bin...)
+// TODO:
+//func TestBinaryEndingWithText(t *testing.T) {
+//}
 
-	scanner := strings.Do(bytes.NewBuffer(input))
-	assertTrue(t, scanner.Scan(), "expected to have data on Scan, none found")
-	assertStrings(t, expected, scanner.Text())
-	assertFalse(t, scanner.Scan(), "expected to have no data on Scan, found some")
+//func TestBinaryWithTextOnMiddle(t *testing.T) {
+//}
+
+//func TestMinTextSizeIsAdjustable(t *testing.T) {
+//}
+
+//func TestEachTextOccurenceIsANewLine(t *testing.T) {
+//}
+
+//func TestJustText(t *testing.T) {
+//}
+
+//func TestJustBinary(t *testing.T) {
+//}
+
+func TestBinaryWithText(t *testing.T) {
+
+	tcases := []testcase{
+		testcase{
+			name:        "startingWithText",
+			minWordSize: 1,
+			input: func() []byte {
+				expected := "textOnBeggining"
+				bin := newBinary(512)
+				return append([]byte(expected), bin...)
+			},
+			output: "textOnBeggining",
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			input := tcase.input()
+			scanner := strings.Do(bytes.NewBuffer(input), tcase.minWordSize)
+
+			lines := []string{}
+			for scanner.Scan() {
+				lines = append(lines, scanner.Text())
+			}
+
+			assertStrings(t, tcase.output, stdstrings.Join(lines, "\n"))
+			if tcase.fail {
+				if scanner.Err() == nil {
+					t.Fatal("expected error, got nil")
+				}
+			}
+		})
+	}
 }
 
-func TestBinaryEndingWithText(t *testing.T) {
-}
-
-func TestBinaryWithTextOnMiddle(t *testing.T) {
-}
-
-func TestMinTextSizeIsAdjustable(t *testing.T) {
-}
-
-func TestEachTextOccurenceIsANewLine(t *testing.T) {
-}
-
-func TestJustText(t *testing.T) {
-}
-
-func TestJustBinary(t *testing.T) {
+type testcase struct {
+	name        string
+	input       func() []byte
+	output      string
+	fail        bool
+	minWordSize int
 }
 
 func newBinary(size uint) []byte {

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -20,6 +20,24 @@ func TestStrings(t *testing.T) {
 
 	tcases := []testcase{
 		testcase{
+			name:        "NonASCIIWordHasOneLessCharThanMin",
+			minWordSize: 2,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte("λ"), bin...)
+			},
+			output: []string{},
+		},
+		testcase{
+			name:        "NonASCIIWordHasMinWordSize",
+			minWordSize: 2,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte("λλ"), bin...)
+			},
+			output: []string{"λλ"},
+		},
+		testcase{
 			name:        "WordHasOneLessCharThanMin",
 			minWordSize: 2,
 			input: func() []byte {
@@ -96,6 +114,26 @@ func TestStrings(t *testing.T) {
 			output: []string{"textOnMiddle"},
 		},
 		testcase{
+			name:        "NonASCIITextOnMiddle",
+			minWordSize: 1,
+			input: func() []byte {
+				expected := "λλλ"
+				bin := newBinary(64)
+				return append(bin, append([]byte(expected), bin...)...)
+			},
+			output: []string{"λλλ"},
+		},
+		testcase{
+			name:        "ASCIIAndNonASCII",
+			minWordSize: 1,
+			input: func() []byte {
+				expected := "(define (λ (x) (+ x a)))"
+				bin := newBinary(64)
+				return append(bin, append([]byte(expected), bin...)...)
+			},
+			output: []string{"(define (λ (x) (+ x a)))"},
+		},
+		testcase{
 			name:        "TextOnEnd",
 			minWordSize: 1,
 			input: func() []byte {
@@ -135,6 +173,21 @@ func TestStrings(t *testing.T) {
 				return t
 			},
 			output: []string{"text", "text"},
+		},
+		testcase{
+			name:        "NonASCIITextSeparatedByBinary",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				text := []byte("awesomeλ=)")
+				t := []byte{}
+				t = append(t, bin...)
+				t = append(t, text...)
+				t = append(t, bin...)
+				t = append(t, text...)
+				return t
+			},
+			output: []string{"awesomeλ=)", "awesomeλ=)"},
 		},
 		testcase{
 			name:        "WordsAreNotAccumulativeBetweenBinData",
@@ -189,7 +242,9 @@ type testcase struct {
 }
 
 func newBinary(size uint) []byte {
-	// TODO: Not the most awesome random binary =/
+	// WHY: Starting with the most significant bit as 1 helps to test
+	// UTF-8 corner cases. Don't change this without providing
+	// testing for this
 	bin := make([]byte, size)
 	for i := 0; i < int(size); i++ {
 		bin[i] = 0xFF

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -261,34 +261,41 @@ func TestStrings(t *testing.T) {
 		},
 	}
 
+	minBinChunkSize := 1
+	maxBinChunkSize := 1024
+
 	for _, tcase := range tcases {
-		t.Run(tcase.name, func(t *testing.T) {
-			bin := newBinary(10)
-			input := tcase.input(bin)
-			scanner := strings.Do(bytes.NewBuffer(input), tcase.minWordSize)
+		for i := minBinChunkSize; i <= maxBinChunkSize; i++ {
+			binsize := i
+			testname := fmt.Sprintf("%s/binSize%d", tcase.name, binsize)
+			t.Run(testname, func(t *testing.T) {
+				bin := newBinary(uint(binsize))
+				input := tcase.input(bin)
+				scanner := strings.Do(bytes.NewBuffer(input), tcase.minWordSize)
 
-			lines := []string{}
-			for scanner.Scan() {
-				lines = append(lines, scanner.Text())
-			}
-
-			if len(lines) != len(tcase.output) {
-				t.Fatalf("wanted[%s] got[%s]", tcase.output, lines)
-			}
-
-			for i, want := range tcase.output {
-				got := lines[i]
-				if want != got {
-					t.Errorf("unexpected line at[%d]", i)
-					t.Errorf("wanted[%s] got[%s]", want, got)
-					t.Errorf("wantedLines[%s] gotLines[%s]", tcase.output, lines)
+				lines := []string{}
+				for scanner.Scan() {
+					lines = append(lines, scanner.Text())
 				}
-			}
 
-			if scanner.Err() != nil {
-				t.Fatal("unexpected error[%s]", scanner.Err())
-			}
-		})
+				if len(lines) != len(tcase.output) {
+					t.Fatalf("wanted[%s] got[%s]", tcase.output, lines)
+				}
+
+				for i, want := range tcase.output {
+					got := lines[i]
+					if want != got {
+						t.Errorf("unexpected line at[%d]", i)
+						t.Errorf("wanted[%s] got[%s]", want, got)
+						t.Errorf("wantedLines[%s] gotLines[%s]", tcase.output, lines)
+					}
+				}
+
+				if scanner.Err() != nil {
+					t.Fatal("unexpected error[%s]", scanner.Err())
+				}
+			})
+		}
 	}
 }
 

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -13,9 +13,6 @@ import (
 //func TestMinTextSizeIsAdjustable(t *testing.T) {
 //}
 
-//func TestEachTextOccurenceIsANewLine(t *testing.T) {
-//}
-
 func TestStrings(t *testing.T) {
 
 	tcases := []testcase{
@@ -64,6 +61,21 @@ func TestStrings(t *testing.T) {
 				return newBinary(64)
 			},
 			output: []string{},
+		},
+		testcase{
+			name:        "TextSeparatedByBinary",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				text := []byte("text")
+				t := []byte{}
+				t = append(t, bin...)
+				t = append(t, text...)
+				t = append(t, bin...)
+				t = append(t, text...)
+				return t
+			},
+			output: []string{"text", "text"},
 		},
 	}
 

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -1,0 +1,68 @@
+package strings_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/NeowayLabs/nash/stdbin/strings"
+)
+
+func TestBinaryStartingWithText(t *testing.T) {
+	expected := "textOnBeggining"
+	bin := newBinary(512)
+	input := append([]byte(expected), bin...)
+
+	scanner := strings.Do(bytes.NewBuffer(input))
+	assertTrue(t, scanner.Scan(), "expected to have data on Scan, none found")
+	assertStrings(t, expected, scanner.Text())
+	assertFalse(t, scanner.Scan(), "expected to have no data on Scan, found some")
+}
+
+func TestBinaryEndingWithText(t *testing.T) {
+}
+
+func TestBinaryWithTextOnMiddle(t *testing.T) {
+}
+
+func TestMinTextSizeIsAdjustable(t *testing.T) {
+}
+
+func TestEachTextOccurenceIsANewLine(t *testing.T) {
+}
+
+func TestJustText(t *testing.T) {
+}
+
+func TestJustBinary(t *testing.T) {
+}
+
+func newBinary(size uint) []byte {
+	// TODO: Not the most awesome random binary =/
+	bin := make([]byte, size)
+	for i := 0; i < int(size); i++ {
+		bin[i] = 0xFF
+	}
+	return bin
+}
+
+// TODO: Start an assert package on nash or use our other project ?
+func assertTrue(t *testing.T, b bool, msg string) {
+	t.Helper()
+	if !b {
+		t.Fatalf("want true, got false: %s", msg)
+	}
+}
+
+func assertFalse(t *testing.T, b bool, msg string) {
+	t.Helper()
+	if b {
+		t.Fatalf("want false, got true: %s", msg)
+	}
+}
+
+func assertStrings(t *testing.T, want string, got string) {
+	t.Helper()
+	if want != got {
+		t.Fatalf("want[%s] != got[%s]", want, got)
+	}
+}

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/NeowayLabs/nash/stdbin/strings"
 )
 
-// TODO
-// Handle io.Reader returning n=0 and error=nil (nothing happened)
-// Handle io.Reader returning n>0 and error!=nil (can be a last read)
+// TODO: Test first byte is rune start but also a EOF, should not search for rest of the rune
 
 func TestStrings(t *testing.T) {
 
@@ -25,7 +23,7 @@ func TestStrings(t *testing.T) {
 	}
 
 	tcases := []testcase{
-		testcase{
+		{
 			name:        "UTF-8With2Bytes",
 			minWordSize: 1,
 			input: func() []byte {
@@ -34,7 +32,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"λ"},
 		},
-		testcase{
+		{
 			name:        "UTF-8With3Bytes",
 			minWordSize: 1,
 			input: func() []byte {
@@ -43,7 +41,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"€"},
 		},
-		testcase{
+		{
 			name:        "UTF-8With4Bytes",
 			minWordSize: 1,
 			input: func() []byte {
@@ -52,7 +50,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"𐍈"},
 		},
-		testcase{
+		{
 			name:        "NonASCIIWordHasOneLessCharThanMin",
 			minWordSize: 2,
 			input: func() []byte {
@@ -61,7 +59,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{},
 		},
-		testcase{
+		{
 			name:        "NonASCIIWordHasMinWordSize",
 			minWordSize: 2,
 			input: func() []byte {
@@ -70,7 +68,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"λλ"},
 		},
-		testcase{
+		{
 			name:        "WordHasOneLessCharThanMin",
 			minWordSize: 2,
 			input: func() []byte {
@@ -79,7 +77,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{},
 		},
-		testcase{
+		{
 			name:        "WordHasMinWordSize",
 			minWordSize: 2,
 			input: func() []byte {
@@ -88,7 +86,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"kz"},
 		},
-		testcase{
+		{
 			name:        "WordHasOneMoreCharThanMinWordSize",
 			minWordSize: 2,
 			input: func() []byte {
@@ -97,7 +95,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"ktz"},
 		},
-		testcase{
+		{
 			name:        "StartingWithOneChar",
 			minWordSize: 1,
 			input: func() []byte {
@@ -106,7 +104,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"k"},
 		},
-		testcase{
+		{
 			name:        "EndWithOneChar",
 			minWordSize: 1,
 			input: func() []byte {
@@ -115,7 +113,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"k"},
 		},
-		testcase{
+		{
 			name:        "OneCharInTheMiddle",
 			minWordSize: 1,
 			input: func() []byte {
@@ -126,7 +124,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"k"},
 		},
-		testcase{
+		{
 			name:        "StartingWithText",
 			minWordSize: 1,
 			input: func() []byte {
@@ -136,7 +134,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"textOnBeggining"},
 		},
-		testcase{
+		{
 			name:        "TextOnMiddle",
 			minWordSize: 1,
 			input: func() []byte {
@@ -146,7 +144,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"textOnMiddle"},
 		},
-		testcase{
+		{
 			name:        "NonASCIITextOnMiddle",
 			minWordSize: 1,
 			input: func() []byte {
@@ -156,7 +154,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"λλλ"},
 		},
-		testcase{
+		{
 			name:        "ASCIIAndNonASCII",
 			minWordSize: 1,
 			input: func() []byte {
@@ -166,7 +164,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"(define (λ (x) (+ x a)))"},
 		},
-		testcase{
+		{
 			name:        "TextOnEnd",
 			minWordSize: 1,
 			input: func() []byte {
@@ -176,7 +174,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"textOnEnd"},
 		},
-		testcase{
+		{
 			name:        "JustText",
 			minWordSize: 1,
 			input: func() []byte {
@@ -184,7 +182,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"justtext"},
 		},
-		testcase{
+		{
 			name:        "JustBinary",
 			minWordSize: 1,
 			input: func() []byte {
@@ -192,7 +190,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{},
 		},
-		testcase{
+		{
 			name:        "TextSeparatedByBinary",
 			minWordSize: 1,
 			input: func() []byte {
@@ -207,7 +205,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"text", "text"},
 		},
-		testcase{
+		{
 			name:        "NonASCIITextSeparatedByBinary",
 			minWordSize: 1,
 			input: func() []byte {
@@ -222,7 +220,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"awesomeλ=)", "awesomeλ=)"},
 		},
-		testcase{
+		{
 			name:        "WordsAreNotAccumulativeBetweenBinData",
 			minWordSize: 2,
 			input: func() []byte {
@@ -232,32 +230,32 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{},
 		},
-		testcase{
+		{
 			name:        "ASCIISeparatedByByteThatLooksLikeUTF",
 			minWordSize: 1,
 			input: func() []byte {
 				bin := newBinary(64)
 				return append([]byte{
 					'n',
-					byte(0xC2),
+					runestart,
 					'k',
 				}, bin...)
 			},
 			output: []string{"n", "k"},
 		},
-		testcase{
+		{
 			name:        "ASCIIAfterPossibleFirstByteOfUTF",
 			minWordSize: 1,
 			input: func() []byte {
 				bin := newBinary(64)
 				return append([]byte{
-					byte(0xC2),
+					runestart,
 					'k',
 				}, bin...)
 			},
 			output: []string{"k"},
 		},
-		testcase{
+		{
 			name:        "ASCIIAfterPossibleSecondByteOfUTF",
 			minWordSize: 1,
 			input: func() []byte {
@@ -270,7 +268,7 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{"k"},
 		},
-		testcase{
+		{
 			name:        "ASCIIAfterPossibleThirdByteOfUTF",
 			minWordSize: 1,
 			input: func() []byte {
@@ -345,7 +343,7 @@ func TestStringsReadErrorAfterValidUTF9StartingByte(t *testing.T) {
 			return 0, errors.New("fake injected error")
 		}
 		sentFirstByte = true
-		d[0] = 0xC2
+		d[0] = runestart
 		return 1, nil
 	}), minWordSize)
 	assertScannerFails(t, scanner, 1)
@@ -371,6 +369,89 @@ func TestStringsReadCanReturnEOFWithData(t *testing.T) {
 		t.Fatalf("want[%s] != got[%s]", string(want), got)
 	}
 }
+
+func TestStringReadErrors(t *testing.T) {
+
+	type readresult struct {
+		data byte
+		err  error
+	}
+
+	type errorcase struct {
+		name    string
+		results []readresult
+	}
+
+	errorcases := []errorcase{
+		{
+			name: "NoReadAfterError",
+			results: []readresult{
+				{
+					err: errors.New("injected error"),
+				},
+			},
+		},
+		{
+			name: "NoReadAfterEOF",
+			results: []readresult{
+				{
+					err: io.EOF,
+				},
+			},
+		},
+		{
+			name: "NoReadAfterErrorSearchingForUTF",
+			results: []readresult{
+				{data: runestart},
+				{err: errors.New("surprise moderfocker")},
+			},
+		},
+	}
+
+	for _, tcase := range errorcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			var minWordSize uint = 1
+			var fatalerr error
+
+			calls := 0
+
+			scanner := strings.Do(newFakeReader(func(d []byte) (int, error) {
+				if fatalerr != nil {
+					return 0, fatalerr
+				}
+				calls += 1
+
+				if calls > len(tcase.results) {
+					fatalerr = fmt.Errorf(
+						"expected [%d] reads but got[%d]",
+						len(tcase.results),
+						calls,
+					)
+					return 0, fatalerr
+				}
+				written := 0
+				result := tcase.results[calls-1]
+				if result.data != 0 && len(d) > 0 {
+					d[0] = result.data
+					written = 1
+				}
+				return written, result.err
+			}), minWordSize)
+
+			for scanner.Scan() {
+			}
+
+			if fatalerr != nil {
+				t.Fatal(fatalerr.Error())
+			}
+			if calls != len(tcase.results) {
+				t.Fatalf("expected [%d] Read calls, got[%d]", len(tcase.results), calls)
+			}
+		})
+	}
+}
+
+const runestart byte = 0xC2
 
 type FakeReader struct {
 	read func([]byte) (int, error)

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -20,6 +20,33 @@ func TestStrings(t *testing.T) {
 
 	tcases := []testcase{
 		testcase{
+			name:        "WordHasOneLessCharThanMin",
+			minWordSize: 2,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte("k"), bin...)
+			},
+			output: []string{},
+		},
+		testcase{
+			name:        "WordHasMinWordSize",
+			minWordSize: 2,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte("kz"), bin...)
+			},
+			output: []string{"kz"},
+		},
+		testcase{
+			name:        "WordHasOneMoreCharThanMinWordSize",
+			minWordSize: 2,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte("ktz"), bin...)
+			},
+			output: []string{"ktz"},
+		},
+		testcase{
 			name:        "StartingWithOneChar",
 			minWordSize: 1,
 			input: func() []byte {
@@ -108,6 +135,16 @@ func TestStrings(t *testing.T) {
 				return t
 			},
 			output: []string{"text", "text"},
+		},
+		testcase{
+			name:        "WordsAreNotAccumulativeBetweenBinData",
+			minWordSize: 2,
+			input: func() []byte {
+				bin := newBinary(64)
+				t := append([]byte("k"), bin...)
+				return append(t, byte('t'))
+			},
+			output: []string{},
 		},
 	}
 

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -185,7 +185,7 @@ type testcase struct {
 	input       func() []byte
 	output      []string
 	fail        bool
-	minWordSize int
+	minWordSize uint
 }
 
 func newBinary(size uint) []byte {

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -27,7 +27,7 @@ func TestStrings(t *testing.T) {
 			name:        "UTF-8With2Bytes",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte("λ"), bin...)
 			},
 			output: []string{"λ"},
@@ -36,7 +36,7 @@ func TestStrings(t *testing.T) {
 			name:        "UTF-8With3Bytes",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte("€"), bin...)
 			},
 			output: []string{"€"},
@@ -45,7 +45,7 @@ func TestStrings(t *testing.T) {
 			name:        "UTF-8With4Bytes",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte("𐍈"), bin...)
 			},
 			output: []string{"𐍈"},
@@ -54,7 +54,7 @@ func TestStrings(t *testing.T) {
 			name:        "NonASCIIWordHasOneLessCharThanMin",
 			minWordSize: 2,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte("λ"), bin...)
 			},
 			output: []string{},
@@ -63,7 +63,7 @@ func TestStrings(t *testing.T) {
 			name:        "NonASCIIWordHasMinWordSize",
 			minWordSize: 2,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte("λλ"), bin...)
 			},
 			output: []string{"λλ"},
@@ -72,7 +72,7 @@ func TestStrings(t *testing.T) {
 			name:        "WordHasOneLessCharThanMin",
 			minWordSize: 2,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte("k"), bin...)
 			},
 			output: []string{},
@@ -81,7 +81,7 @@ func TestStrings(t *testing.T) {
 			name:        "WordHasMinWordSize",
 			minWordSize: 2,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte("kz"), bin...)
 			},
 			output: []string{"kz"},
@@ -90,7 +90,7 @@ func TestStrings(t *testing.T) {
 			name:        "WordHasOneMoreCharThanMinWordSize",
 			minWordSize: 2,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte("ktz"), bin...)
 			},
 			output: []string{"ktz"},
@@ -99,7 +99,7 @@ func TestStrings(t *testing.T) {
 			name:        "StartingWithOneChar",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte("k"), bin...)
 			},
 			output: []string{"k"},
@@ -108,7 +108,7 @@ func TestStrings(t *testing.T) {
 			name:        "EndWithOneChar",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append(bin, []byte("k")...)
 			},
 			output: []string{"k"},
@@ -117,7 +117,7 @@ func TestStrings(t *testing.T) {
 			name:        "OneCharInTheMiddle",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				t := append(bin, []byte("k")...)
 				t = append(t, bin...)
 				return t
@@ -129,7 +129,7 @@ func TestStrings(t *testing.T) {
 			minWordSize: 1,
 			input: func() []byte {
 				expected := "textOnBeggining"
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte(expected), bin...)
 			},
 			output: []string{"textOnBeggining"},
@@ -139,7 +139,7 @@ func TestStrings(t *testing.T) {
 			minWordSize: 1,
 			input: func() []byte {
 				expected := "textOnMiddle"
-				bin := newBinary(64)
+				bin := newBinary()
 				return append(bin, append([]byte(expected), bin...)...)
 			},
 			output: []string{"textOnMiddle"},
@@ -149,7 +149,7 @@ func TestStrings(t *testing.T) {
 			minWordSize: 1,
 			input: func() []byte {
 				expected := "λλλ"
-				bin := newBinary(64)
+				bin := newBinary()
 				return append(bin, append([]byte(expected), bin...)...)
 			},
 			output: []string{"λλλ"},
@@ -159,7 +159,7 @@ func TestStrings(t *testing.T) {
 			minWordSize: 1,
 			input: func() []byte {
 				expected := "(define (λ (x) (+ x a)))"
-				bin := newBinary(64)
+				bin := newBinary()
 				return append(bin, append([]byte(expected), bin...)...)
 			},
 			output: []string{"(define (λ (x) (+ x a)))"},
@@ -169,7 +169,7 @@ func TestStrings(t *testing.T) {
 			minWordSize: 1,
 			input: func() []byte {
 				expected := "textOnEnd"
-				bin := newBinary(64)
+				bin := newBinary()
 				return append(bin, append([]byte(expected), bin...)...)
 			},
 			output: []string{"textOnEnd"},
@@ -186,7 +186,7 @@ func TestStrings(t *testing.T) {
 			name:        "JustBinary",
 			minWordSize: 1,
 			input: func() []byte {
-				return newBinary(64)
+				return newBinary()
 			},
 			output: []string{},
 		},
@@ -194,7 +194,7 @@ func TestStrings(t *testing.T) {
 			name:        "TextSeparatedByBinary",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				text := []byte("text")
 				t := []byte{}
 				t = append(t, bin...)
@@ -209,7 +209,7 @@ func TestStrings(t *testing.T) {
 			name:        "NonASCIITextSeparatedByBinary",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				text := []byte("awesomeλ=)")
 				t := []byte{}
 				t = append(t, bin...)
@@ -224,7 +224,7 @@ func TestStrings(t *testing.T) {
 			name:        "WordsAreNotAccumulativeBetweenBinData",
 			minWordSize: 2,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				t := append([]byte("k"), bin...)
 				return append(t, byte('t'))
 			},
@@ -234,7 +234,7 @@ func TestStrings(t *testing.T) {
 			name:        "ASCIISeparatedByByteThatLooksLikeUTF",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte{
 					'n',
 					runestart,
@@ -247,7 +247,7 @@ func TestStrings(t *testing.T) {
 			name:        "ASCIIAfterPossibleFirstByteOfUTF",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte{
 					runestart,
 					'k',
@@ -259,7 +259,7 @@ func TestStrings(t *testing.T) {
 			name:        "ASCIIAfterPossibleSecondByteOfUTF",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte{
 					byte(0xE2),
 					byte(0x82),
@@ -272,7 +272,7 @@ func TestStrings(t *testing.T) {
 			name:        "ASCIIAfterPossibleThirdByteOfUTF",
 			minWordSize: 1,
 			input: func() []byte {
-				bin := newBinary(64)
+				bin := newBinary()
 				return append([]byte{
 					byte(0xF0),
 					byte(0x90),
@@ -335,7 +335,7 @@ func TestStringsReadErrorOnSecondByte(t *testing.T) {
 	assertScannerFails(t, scanner, 1)
 }
 
-func TestStringsReadErrorAfterValidUTF9StartingByte(t *testing.T) {
+func TestStringsReadErrorAfterValidUTF8StartingByte(t *testing.T) {
 	var minWordSize uint = 1
 	sentFirstByte := false
 	scanner := strings.Do(newFakeReader(func(d []byte) (int, error) {
@@ -346,7 +346,7 @@ func TestStringsReadErrorAfterValidUTF9StartingByte(t *testing.T) {
 		d[0] = runestart
 		return 1, nil
 	}), minWordSize)
-	assertScannerFails(t, scanner, 1)
+	assertScannerFails(t, scanner, 0)
 }
 
 func TestStringsReadCanReturnEOFWithData(t *testing.T) {
@@ -367,87 +367,6 @@ func TestStringsReadCanReturnEOFWithData(t *testing.T) {
 	got := scanner.Text()
 	if string(want) != got {
 		t.Fatalf("want[%s] != got[%s]", string(want), got)
-	}
-}
-
-func TestStringReadErrors(t *testing.T) {
-
-	type readresult struct {
-		data byte
-		err  error
-	}
-
-	type errorcase struct {
-		name    string
-		results []readresult
-	}
-
-	errorcases := []errorcase{
-		{
-			name: "NoReadAfterError",
-			results: []readresult{
-				{
-					err: errors.New("injected error"),
-				},
-			},
-		},
-		{
-			name: "NoReadAfterEOF",
-			results: []readresult{
-				{
-					err: io.EOF,
-				},
-			},
-		},
-		{
-			name: "NoReadAfterErrorSearchingForUTF",
-			results: []readresult{
-				{data: runestart},
-				{err: errors.New("surprise moderfocker")},
-			},
-		},
-	}
-
-	for _, tcase := range errorcases {
-		t.Run(tcase.name, func(t *testing.T) {
-			var minWordSize uint = 1
-			var fatalerr error
-
-			calls := 0
-
-			scanner := strings.Do(newFakeReader(func(d []byte) (int, error) {
-				if fatalerr != nil {
-					return 0, fatalerr
-				}
-				calls += 1
-
-				if calls > len(tcase.results) {
-					fatalerr = fmt.Errorf(
-						"expected [%d] reads but got[%d]",
-						len(tcase.results),
-						calls,
-					)
-					return 0, fatalerr
-				}
-				written := 0
-				result := tcase.results[calls-1]
-				if result.data != 0 && len(d) > 0 {
-					d[0] = result.data
-					written = 1
-				}
-				return written, result.err
-			}), minWordSize)
-
-			for scanner.Scan() {
-			}
-
-			if fatalerr != nil {
-				t.Fatal(fatalerr.Error())
-			}
-			if calls != len(tcase.results) {
-				t.Fatalf("expected [%d] Read calls, got[%d]", len(tcase.results), calls)
-			}
-		})
 	}
 }
 
@@ -483,11 +402,12 @@ func assertScannerFails(t *testing.T, scanner *bufio.Scanner, expectedIter uint)
 	}
 }
 
-func newBinary(size uint) []byte {
+func newBinary() []byte {
 	// WHY: Starting with the most significant bit as 1 helps to test
 	// UTF-8 corner cases. Don't change this without providing
 	// testing for this. Not the best way to do this (not explicit)
 	// but it is what we have for today =).
+	size := 10
 	bin := make([]byte, size)
 	for i := 0; i < int(size); i++ {
 		bin[i] = 0xFF

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -8,17 +8,38 @@ import (
 )
 
 // TODO
-
 // Test fatal error on input io.Reader
-
-// Test word size is relative to rune not bytes (practice some chinese)
-
-//func TestMinTextSizeIsAdjustable(t *testing.T) {
-//}
 
 func TestStrings(t *testing.T) {
 
 	tcases := []testcase{
+		testcase{
+			name:        "UTF-8With2Bytes",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte("λ"), bin...)
+			},
+			output: []string{"λ"},
+		},
+		testcase{
+			name:        "UTF-8With3Bytes",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte("€"), bin...)
+			},
+			output: []string{"€"},
+		},
+		testcase{
+			name:        "UTF-8With4Bytes",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte("𐍈"), bin...)
+			},
+			output: []string{"𐍈"},
+		},
 		testcase{
 			name:        "NonASCIIWordHasOneLessCharThanMin",
 			minWordSize: 2,
@@ -244,7 +265,8 @@ type testcase struct {
 func newBinary(size uint) []byte {
 	// WHY: Starting with the most significant bit as 1 helps to test
 	// UTF-8 corner cases. Don't change this without providing
-	// testing for this
+	// testing for this. Not the best way to do this (not explicit)
+	// but it is what we have for today =).
 	bin := make([]byte, size)
 	for i := 0; i < int(size); i++ {
 		bin[i] = 0xFF

--- a/stdbin/strings/strings_test.go
+++ b/stdbin/strings/strings_test.go
@@ -220,6 +220,45 @@ func TestStrings(t *testing.T) {
 			},
 			output: []string{},
 		},
+		testcase{
+			name:        "ASCIIAfterPossibleFirstByteOfUTF",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte{
+					byte(0xC2),
+					'k',
+				}, bin...)
+			},
+			output: []string{"k"},
+		},
+		testcase{
+			name:        "ASCIIAfterPossibleSecondByteOfUTF",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte{
+					byte(0xE2),
+					byte(0x82),
+					'k',
+				}, bin...)
+			},
+			output: []string{"k"},
+		},
+		testcase{
+			name:        "ASCIIAfterPossibleThirdByteOfUTF",
+			minWordSize: 1,
+			input: func() []byte {
+				bin := newBinary(64)
+				return append([]byte{
+					byte(0xF0),
+					byte(0x90),
+					byte(0x8D),
+					'k',
+				}, bin...)
+			},
+			output: []string{"k"},
+		},
 	}
 
 	for _, tcase := range tcases {


### PR DESCRIPTION
![satan](https://raw.githubusercontent.com/katcipis/memes/master/satan.jpg)

Inspired on what I read about the "strings" exec on the book The Practice of Programming.

I think we can achieve something that has one parameter...the word size...instead of this:

https://sourceware.org/binutils/docs-2.23/binutils/strings.html

Things like "target" makes no sense to me...why not just print every stream of printable characters found ? It is how it is implemented on the book and I liked it =D