### PR TITLE
print init loading fatal error instead of exiting

### DIFF
--- a/cmd/nash/cli.go
+++ b/cmd/nash/cli.go
@@ -65,9 +65,8 @@ func importInitFile(shell *nash.Shell, initFile string) (bool, error) {
 	return false, nil
 }
 
-func setupCli(shell *nash.Shell) error {
-	shell.SetInteractive(true)
-
+func loadInit(shell *nash.Shell) error {
+	
 	if noInit {
 		return nil
 	}
@@ -91,8 +90,11 @@ func setupCli(shell *nash.Shell) error {
 }
 
 func cli(shell *nash.Shell) error {
-	if err := setupCli(shell); err != nil {
-		return err
+
+	shell.SetInteractive(true)
+
+	if err := loadInit(shell); err != nil {
+		fmt.Fprintf(os.Stderr, "error loading init file:\n%s\n", err)
 	}
 
 	historyFile := shell.DotDir() + "/history"


### PR DESCRIPTION
A lot of times I shot myself on the foot being unable to start terminals on taowm and rio and not knowing why they where not loading (could be a lot of different things) but was actually some error loading my nash init.sh. It seems better to drop the user on a default prompt so he can fix any kind of mistake instead of just exiting the process (which causes the entire terminal to close).