### PR TITLE
Dont abort on invalid NASHPATH/NASHROOT

### DIFF
--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -153,7 +153,11 @@ func NewShell(
 	
 	err = validateDirs(nashpath, nashroot)
 	if err != nil {
-		shell.Stderr().Write([]byte(err.Error() + "\n"))
+		printerr := func(msg string) {
+			shell.Stderr().Write([]byte(msg + "\n"))
+		}
+		printerr(err.Error())
+		printerr("please check your NASHPATH and NASHROOT so they point to valid locations")
 	}
 	
 	return shell, nil

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -62,7 +62,7 @@ type (
 		parent *Shell
 
 		repr string // string representation
-		
+
 		nashpath string
 		nashroot string
 
@@ -140,8 +140,8 @@ func NewShell(
 		Mutex:       &sync.Mutex{},
 		sigs:        make(chan os.Signal, 1),
 		filename:    "<interactive>",
-		nashpath: nashpath,
-		nashroot: nashroot,
+		nashpath:    nashpath,
+		nashroot:    nashroot,
 	}
 
 	err := shell.setup()
@@ -150,7 +150,7 @@ func NewShell(
 	}
 
 	shell.setupSignals()
-	
+
 	err = validateDirs(nashpath, nashroot)
 	if err != nil {
 		printerr := func(msg string) {
@@ -159,7 +159,7 @@ func NewShell(
 		printerr(err.Error())
 		printerr("please check your NASHPATH and NASHROOT so they point to valid locations")
 	}
-	
+
 	return shell, nil
 }
 
@@ -941,7 +941,6 @@ func isValidNashRoot(nashroot string) bool {
 	return err == nil
 }
 
-
 func (shell *Shell) executeImport(node *ast.ImportNode) error {
 	obj, err := shell.evalExpr(node.Path)
 	if err != nil {
@@ -987,9 +986,9 @@ func (shell *Shell) executeImport(node *ast.ImportNode) error {
 	if !hasExt {
 		tries = append(tries, filepath.Join(shell.nashpath, "lib", fname+".sh"))
 	}
-	
+
 	tries = append(tries, filepath.Join(shell.nashroot, "stdlib", fname+".sh"))
-	
+
 	shell.logf("Trying %q\n", tries)
 
 	for _, path := range tries {
@@ -2465,7 +2464,7 @@ func validateDirs(nashpath string, nashroot string) error {
 	}
 	err := validateDir(nashpath)
 	if err != nil {
-		return fmt.Errorf("error[%s]: invalid nashpath, history won't be saved", err)
+		return fmt.Errorf("error[%s]: invalid nashpath, user's config won't be loaded", err)
 	}
 	err = validateDir(nashroot)
 	if err != nil {

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -117,13 +117,7 @@ func (e *errStopWalking) StopWalking() bool { return true }
 // NewShell creates a new shell object
 // nashpath will be used to search libraries and nashroot will be used to
 // search for the standard library shipped with the language.
-func NewShell(
-	nashpath string,
-	nashroot string,
-	stdin io.Reader,
-	stdout io.Writer,
-	stderr io.Writer,
-) (*Shell, error) {
+func NewShell(nashpath string, nashroot string) (*Shell, error) {
 
 	shell := &Shell{
 		name:        "parent scope",
@@ -131,9 +125,9 @@ func NewShell(
 		isFn:        false,
 		logf:        NewLog(logNS, false),
 		nashdPath:   nashdAutoDiscover(),
-		stdout:      stdout,
-		stderr:      stderr,
-		stdin:       stdin,
+		stdout:      os.Stdout,
+		stderr:      os.Stderr,
+		stdin:       os.Stdin,
 		env:         make(Env),
 		vars:        make(Var),
 		binds:       make(Fns),

--- a/internal/sh/shell.go
+++ b/internal/sh/shell.go
@@ -2464,11 +2464,11 @@ func validateDirs(nashpath string, nashroot string) error {
 	}
 	err := validateDir(nashpath)
 	if err != nil {
-		return fmt.Errorf("error[%s]: invalid nashpath, user's config won't be loaded", err)
+		return fmt.Errorf("invalid nashpath, user's config won't be loaded: error: %s", err)
 	}
 	err = validateDir(nashroot)
 	if err != nil {
-		return fmt.Errorf("error[%s]: invalid nashroot, stdlib/stdbin won't be available", err)
+		return fmt.Errorf("invalid nashroot, stdlib/stdbin won't be available: error: %s", err)
 	}
 	return nil
 }

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -9,14 +9,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	// FIXME: depending on other sh package on the internal sh tests seems very odd
 	shtypes "github.com/NeowayLabs/nash/sh"
-	
+
 	"github.com/NeowayLabs/nash/internal/sh"
 	"github.com/NeowayLabs/nash/internal/sh/internal/fixture"
 	"github.com/NeowayLabs/nash/tests"
@@ -34,13 +34,11 @@ type (
 
 	testFixture struct {
 		shell     *sh.Shell
-		shellOut *bytes.Buffer
+		shellOut  *bytes.Buffer
 		dir       string
 		nashdPath string
 	}
 )
-
-
 
 func TestInitEnv(t *testing.T) {
 	os.Setenv("TEST", "abc=123=")
@@ -841,7 +839,7 @@ func TestExecuteIfElseIf(t *testing.T) {
 
 	shell := f.shell
 	out := f.shellOut
-	
+
 	err := shell.Exec("test if else", `
         if "" == "" {
             echo "if still works"
@@ -1339,13 +1337,11 @@ func TestExecuteUnixRedirection(t *testing.T) {
 	done := make(chan bool)
 	writeDone := make(chan bool)
 
-
-
 	go func() {
-	
+
 		f, teardown := setup(t)
 		defer teardown()
-		
+
 		defer func() {
 			writeDone <- true
 		}()
@@ -1405,7 +1401,7 @@ func TestExecuteUDPRedirection(t *testing.T) {
 	go func() {
 		f, teardown := setup(t)
 		defer teardown()
-		
+
 		defer func() {
 			writeDone <- true
 		}()
@@ -1550,7 +1546,7 @@ func TestExecuteFnAsFirstClass(t *testing.T) {
 
 	shell := f.shell
 	out := f.shellOut
-	
+
 	err := shell.Exec("test fn by arg", `
         fn printer(val) {
                 echo -n $val
@@ -1792,7 +1788,7 @@ echo -n $list[$a[0]]`)
 func TestExecuteSubShellDoesNotOverwriteparentEnv(t *testing.T) {
 	f, teardown := setup(t)
 	defer teardown()
-	
+
 	shell := f.shell
 	out := f.shellOut
 
@@ -1825,7 +1821,7 @@ echo -n $SHELL`)
 func TestExecuteInterruptDoesNotCancelLoop(t *testing.T) {
 	f, teardown := setup(t)
 	defer teardown()
-	
+
 	shell := f.shell
 	shell.TriggerCTRLC()
 
@@ -1843,7 +1839,7 @@ for i in $seq {}`)
 func TestExecuteErrorSuppressionAll(t *testing.T) {
 	f, teardown := setup(t)
 	defer teardown()
-	
+
 	shell := f.shell
 
 	err := shell.Exec("-input-", `var _, status <= command-not-exists`)
@@ -1889,7 +1885,7 @@ func TestExecuteErrorSuppressionAll(t *testing.T) {
 func TestExecuteGracefullyError(t *testing.T) {
 	f, teardown := setup(t)
 	defer teardown()
-	
+
 	shell := f.shell
 
 	err := shell.Exec("someinput.sh", "(")
@@ -1921,7 +1917,7 @@ func TestExecuteGracefullyError(t *testing.T) {
 func TestExecuteMultilineCmd(t *testing.T) {
 	f, teardown := setup(t)
 	defer teardown()
-	
+
 	shell := f.shell
 	out := f.shellOut
 
@@ -1964,10 +1960,10 @@ func TestExecuteMultilineCmd(t *testing.T) {
 func TestExecuteMultilineCmdAssign(t *testing.T) {
 	f, teardown := setup(t)
 	defer teardown()
-	
+
 	shell := f.shell
 	out := f.shellOut
-	
+
 	err := shell.Exec("test", `var val <= (echo -n
 		hello
 		world)
@@ -2010,7 +2006,7 @@ func TestExecuteMultilineCmdAssign(t *testing.T) {
 func TestExecuteMultiReturnUnfinished(t *testing.T) {
 	f, teardown := setup(t)
 	defer teardown()
-	
+
 	shell := f.shell
 
 	err := shell.Exec("test", "(")
@@ -2148,19 +2144,19 @@ a()`,
 func setup(t *testing.T) (testFixture, func()) {
 
 	dirs := fixture.SetupNashDirs(t)
-	
-	shell, err := sh.NewShell(dirs.Path, dirs.Root, os.Stdin, os.Stdout, os.Stderr)
+
+	shell, err := sh.NewShell(dirs.Path, dirs.Root)
 
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	var out bytes.Buffer
 	shell.SetStdout(&out)
-	
+
 	return testFixture{
-		shell: shell,
-		shellOut: &out,
+		shell:     shell,
+		shellOut:  &out,
 		dir:       tests.Testdir,
 		nashdPath: tests.Nashcmd,
 	}, dirs.Cleanup
@@ -2247,7 +2243,7 @@ func testInteractiveExec(t *testing.T, testcase execTestCase) {
 
 	f, teardown := setup(t)
 	defer teardown()
-	
+
 	f.shell.SetInteractive(true)
 	testShellExec(t, f.shell, testcase)
 }

--- a/internal/sh/shell_test.go
+++ b/internal/sh/shell_test.go
@@ -2149,7 +2149,7 @@ func setup(t *testing.T) (testFixture, func()) {
 
 	dirs := fixture.SetupNashDirs(t)
 	
-	shell, err := sh.NewShell(dirs.Path, dirs.Root)
+	shell, err := sh.NewShell(dirs.Path, dirs.Root, os.Stdin, os.Stdout, os.Stderr)
 
 	if err != nil {
 		t.Fatal(err)

--- a/nash.go
+++ b/nash.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/NeowayLabs/nash/ast"
 	shell "github.com/NeowayLabs/nash/internal/sh"
@@ -22,7 +21,7 @@ type (
 
 // New creates a new `nash.Shell` instance.
 func New(nashpath string, nashroot string) (*Shell, error) {
-	interp, err := shell.NewShell(nashpath, nashroot, os.Stdin, os.Stdout, os.Stderr)
+	interp, err := shell.NewShell(nashpath, nashroot)
 
 	if err != nil {
 		return nil, err

--- a/nash.go
+++ b/nash.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/NeowayLabs/nash/ast"
 	shell "github.com/NeowayLabs/nash/internal/sh"
@@ -21,7 +22,7 @@ type (
 
 // New creates a new `nash.Shell` instance.
 func New(nashpath string, nashroot string) (*Shell, error) {
-	interp, err := shell.NewShell(nashpath, nashroot)
+	interp, err := shell.NewShell(nashpath, nashroot, os.Stdin, os.Stdout, os.Stderr)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Instead of aborting just print error messages on the shell stderr so the user dont go completely blind without an stdlib. 