### PR TITLE
OSX symlinks for /tmp and /var break the tests

### DIFF
--- a/cmd/nash/install.go
+++ b/cmd/nash/install.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"os"
-	"io"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -21,30 +21,29 @@ func InstallLib(nashpath string, sourcepath string) error {
 	}
 	if filepath.HasPrefix(sourcepathAbs, nashlibdir) {
 		return fmt.Errorf(
-			"lib source path[%s] can't be inside nash lib dir[%s]", sourcepath, nashlibdir) 
+			"lib source path[%s] can't be inside nash lib dir[%s]", sourcepath, nashlibdir)
 	}
 	return installLib(nashlibdir, sourcepathAbs)
 }
 
 func installLib(targetdir string, sourcepath string) error {
-
 	f, err := os.Stat(sourcepath)
 	if err != nil {
 		return fmt.Errorf("error[%s] checking if path[%s] is dir", err, sourcepath)
 	}
-	
+
 	if !f.IsDir() {
 		return copyfile(targetdir, sourcepath)
 	}
-	
+
 	basedir := filepath.Base(sourcepath)
 	targetdir = filepath.Join(targetdir, basedir)
-	
+
 	files, err := ioutil.ReadDir(sourcepath)
 	if err != nil {
 		return fmt.Errorf("error[%s] reading dir[%s]", err, sourcepath)
 	}
-	
+
 	for _, file := range files {
 		err := installLib(targetdir, filepath.Join(sourcepath, file.Name()))
 		if err != nil {
@@ -55,30 +54,29 @@ func installLib(targetdir string, sourcepath string) error {
 }
 
 func copyfile(targetdir string, sourcefilepath string) error {
-
 	fail := func(err error) error {
 		return fmt.Errorf(
 			"error[%s] trying to copy file[%s] to [%s]", err, sourcefilepath, targetdir)
 	}
-	
+
 	err := os.MkdirAll(targetdir, os.ModePerm)
 	if err != nil {
 		return fail(err)
 	}
-	
+
 	sourcefile, err := os.Open(sourcefilepath)
 	if err != nil {
 		return fail(err)
 	}
 	defer sourcefile.Close()
-	
+
 	targetfilepath := filepath.Join(targetdir, filepath.Base(sourcefilepath))
 	targetfile, err := os.Create(targetfilepath)
 	if err != nil {
 		return fail(err)
 	}
 	defer targetfile.Close()
-	
+
 	_, err = io.Copy(targetfile, sourcefile)
 	return err
 }

--- a/cmd/nash/install_test.go
+++ b/cmd/nash/install_test.go
@@ -1,22 +1,21 @@
 package main_test
 
 import (
-	"os"
 	"io/ioutil"
-	"testing"
+	"os"
 	"path/filepath"
-	
-	"github.com/NeowayLabs/nash/cmd/nash"
+	"testing"
+
+	main "github.com/NeowayLabs/nash/cmd/nash"
 	"github.com/NeowayLabs/nash/internal/testing/fixture"
 )
 
 // TODO: test when nashpath lib already exists and has libraries inside
 
 func TestInstallLib(t *testing.T) {
-
 	type testcase struct {
-		name string
-		libfiles []string
+		name        string
+		libfiles    []string
 		installpath string
 		// want will map the wanted files to the original files copied from the lib
 		// the wanted files paths are relative to inside the nashpath lib dir.
@@ -24,7 +23,7 @@ func TestInstallLib(t *testing.T) {
 		// when multiple files are installed.
 		want map[string]string
 	}
-	
+
 	cases := []testcase{
 		{
 			name: "SingleFile",
@@ -32,8 +31,8 @@ func TestInstallLib(t *testing.T) {
 				"/testfile/file.sh",
 			},
 			installpath: "/testfile/file.sh",
-			want : map[string]string{
-				"file.sh" : "/testfile/file.sh",
+			want: map[string]string{
+				"file.sh": "/testfile/file.sh",
 			},
 		},
 		{
@@ -42,8 +41,8 @@ func TestInstallLib(t *testing.T) {
 				"/testfile/file.sh",
 			},
 			installpath: "/testfile",
-			want : map[string]string{
-				"/testfile/file.sh" : "/testfile/file.sh",
+			want: map[string]string{
+				"/testfile/file.sh": "/testfile/file.sh",
 			},
 		},
 		{
@@ -53,9 +52,9 @@ func TestInstallLib(t *testing.T) {
 				"/testfile/fileagain.sh",
 			},
 			installpath: "/testfile",
-			want : map[string]string{
-				"/testfile/file.sh" : "/testfile/file.sh",
-				"/testfile/fileagain.sh" : "/testfile/fileagain.sh",
+			want: map[string]string{
+				"/testfile/file.sh":      "/testfile/file.sh",
+				"/testfile/fileagain.sh": "/testfile/fileagain.sh",
 			},
 		},
 		{
@@ -69,13 +68,13 @@ func TestInstallLib(t *testing.T) {
 				"/testfile/dir2/dir3/file.sh",
 			},
 			installpath: "/testfile",
-			want : map[string]string{
-				"/testfile/file.sh": "/testfile/file.sh",
-				"/testfile/dir1/file.sh" : "/testfile/dir1/file.sh",
+			want: map[string]string{
+				"/testfile/file.sh":           "/testfile/file.sh",
+				"/testfile/dir1/file.sh":      "/testfile/dir1/file.sh",
 				"/testfile/dir1/fileagain.sh": "/testfile/dir1/fileagain.sh",
-				"/testfile/dir2/file.sh": "/testfile/dir2/file.sh",
+				"/testfile/dir2/file.sh":      "/testfile/dir2/file.sh",
 				"/testfile/dir2/fileagain.sh": "/testfile/dir2/fileagain.sh",
-				"/testfile/dir2/dir3/file.sh" : "/testfile/dir2/dir3/file.sh",
+				"/testfile/dir2/dir3/file.sh": "/testfile/dir2/dir3/file.sh",
 			},
 		},
 		{
@@ -89,41 +88,41 @@ func TestInstallLib(t *testing.T) {
 				"/testfile/dir2/dir3/file.sh",
 			},
 			installpath: "/testfile/dir2",
-			want : map[string]string{
-				"/dir2/file.sh": "/testfile/dir2/file.sh",
+			want: map[string]string{
+				"/dir2/file.sh":      "/testfile/dir2/file.sh",
 				"/dir2/fileagain.sh": "/testfile/dir2/fileagain.sh",
-				"/dir2/dir3/file.sh" : "/testfile/dir2/dir3/file.sh",
+				"/dir2/dir3/file.sh": "/testfile/dir2/dir3/file.sh",
 			},
 		},
 	}
-	
+
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			nashpath, rmnashpath := fixture.Tmpdir(t)
 			defer rmnashpath()
-			
+
 			libfilesDir, rmlibfilesDir := fixture.Tmpdir(t)
 			defer rmlibfilesDir()
-			
+
 			nashlibdir := main.NashLibDir(nashpath)
 			libfiles := []string{}
-			
+
 			libfileFullPath := func(libfilepath string) string {
 				return filepath.Join(libfilesDir, libfilepath)
 			}
-			
+
 			for _, f := range c.libfiles {
 				libfiles = append(libfiles, libfileFullPath(f))
 			}
-			
+
 			createdLibFiles := fixture.CreateFiles(t, libfiles)
 			installpath := filepath.Join(libfilesDir, c.installpath)
-			
+
 			err := main.InstallLib(nashpath, installpath)
 			if err != nil {
 				t.Fatal(err)
 			}
-			
+
 			listNashPathFiles := func() []string {
 				files := []string{}
 				filepath.Walk(nashpath, func(path string, stats os.FileInfo, err error) error {
@@ -135,34 +134,33 @@ func TestInstallLib(t *testing.T) {
 				})
 				return files
 			}
-			
+
 			gotFiles := listNashPathFiles()
-			
+
 			fatal := func() {
 				t.Errorf("nashpath: [%s]", nashpath)
 				t.Errorf("nashpath contents:")
-				
+
 				for _, path := range gotFiles {
 					t.Errorf("[%s]", path)
 				}
 				t.Fatal("")
 			}
-			
+
 			if len(gotFiles) != len(c.want) {
 				t.Errorf("wanted[%d] files but got[%d]", len(c.want), len(gotFiles))
 				fatal()
 			}
-			
+
 			for wantFilepath, libfilepath := range c.want {
-			
 				completeLibFilepath := libfileFullPath(libfilepath)
 				wantContents, ok := createdLibFiles[completeLibFilepath]
-				
+
 				if !ok {
 					t.Errorf("unable to find libfilepath[%s] contents on created lib files map[%+v]", completeLibFilepath, createdLibFiles)
 					t.Fatal("this probably means a wrongly specified test case with wanted files that are not present on the libfiles")
 				}
-			
+
 				fullWantFilepath := filepath.Join(nashlibdir, wantFilepath)
 				wantFile, err := os.Open(fullWantFilepath)
 				if err != nil {
@@ -171,12 +169,12 @@ func TestInstallLib(t *testing.T) {
 				}
 				gotContentsRaw, err := ioutil.ReadAll(wantFile)
 				wantFile.Close()
-				
+
 				if err != nil {
 					t.Errorf("error[%s] checking existence of wanted file[%s]", err, wantFilepath)
 					fatal()
 				}
-				
+
 				gotContents := string(gotContentsRaw)
 				if gotContents != wantContents {
 					t.Errorf("for file [%s] wanted contents [%s] but got [%s]", wantFilepath, wantContents, gotContents)
@@ -188,117 +186,117 @@ func TestInstallLib(t *testing.T) {
 }
 
 func TestSourcePathCantBeEqualToNashLibDir(t *testing.T) {
-		nashpath, rmnashpath := fixture.Tmpdir(t)
-		defer rmnashpath()
-		
-		nashlibdir := main.NashLibDir(nashpath)
-		
-		fixture.CreateFile(t, filepath.Join(nashlibdir, "whatever.sh"))
-		
-		assertInstallLibFails(t, nashpath, nashlibdir)
+	nashpath, rmnashpath := fixture.Tmpdir(t)
+	defer rmnashpath()
+
+	nashlibdir := main.NashLibDir(nashpath)
+
+	fixture.CreateFile(t, filepath.Join(nashlibdir, "whatever.sh"))
+
+	assertInstallLibFails(t, nashpath, nashlibdir)
 }
 
 func TestSourcePathCantBeInsideNashLibDir(t *testing.T) {
-		nashpath, rmnashpath := fixture.Tmpdir(t)
-		defer rmnashpath()
-		
-		nashlibdir := main.NashLibDir(nashpath)
-		sourcelibdir := filepath.Join(nashlibdir, "somedir")
-		fixture.CreateFile(t, filepath.Join(sourcelibdir, "whatever.sh"))
-		
-		assertInstallLibFails(t, nashpath, sourcelibdir)
+	nashpath, rmnashpath := fixture.Tmpdir(t)
+	defer rmnashpath()
+
+	nashlibdir := main.NashLibDir(nashpath)
+	sourcelibdir := filepath.Join(nashlibdir, "somedir")
+	fixture.CreateFile(t, filepath.Join(sourcelibdir, "whatever.sh"))
+
+	assertInstallLibFails(t, nashpath, sourcelibdir)
 }
 
 func TestRelativeSourcePathCantBeInsideNashLibDir(t *testing.T) {
-		nashpath, rmnashpath := fixture.Tmpdir(t)
-		defer rmnashpath()
-		
-		nashlibdir := main.NashLibDir(nashpath)
-		fixture.CreateFile(t, filepath.Join(nashlibdir, "somedir", "whatever.sh"))
-		
-		oldwd := fixture.WorkingDir(t)
-		defer fixture.ChangeDir(t, oldwd)
-		
-		fixture.ChangeDir(t, nashlibdir)
-		
-		assertInstallLibFails(t, nashpath, "./somedir")
+	nashpath, rmnashpath := fixture.Tmpdir(t)
+	defer rmnashpath()
+
+	nashlibdir := main.NashLibDir(nashpath)
+	fixture.CreateFile(t, filepath.Join(nashlibdir, "somedir", "whatever.sh"))
+
+	oldwd := fixture.WorkingDir(t)
+	defer fixture.ChangeDir(t, oldwd)
+
+	fixture.ChangeDir(t, nashlibdir)
+
+	assertInstallLibFails(t, nashpath, "./somedir")
 }
 
 func TestFailsOnUnexistentSourcePath(t *testing.T) {
-		nashpath, rmnashpath := fixture.Tmpdir(t)
-		defer rmnashpath()
-		
-		assertInstallLibFails(t, nashpath, "/nonexistent/nash/crap")
+	nashpath, rmnashpath := fixture.Tmpdir(t)
+	defer rmnashpath()
+
+	assertInstallLibFails(t, nashpath, "/nonexistent/nash/crap")
 }
 
 func TestFailsOnUnreadableSourcePath(t *testing.T) {
-		nashpath, rmnashpath := fixture.Tmpdir(t)
-		defer rmnashpath()
-		
-		sourcedir, rmsourcedir := fixture.Tmpdir(t)
-		defer rmsourcedir()
-		
-		fixture.Chmod(t, sourcedir, writeOnly)
-		assertInstallLibFails(t, nashpath, sourcedir)
+	nashpath, rmnashpath := fixture.Tmpdir(t)
+	defer rmnashpath()
+
+	sourcedir, rmsourcedir := fixture.Tmpdir(t)
+	defer rmsourcedir()
+
+	fixture.Chmod(t, sourcedir, writeOnly)
+	assertInstallLibFails(t, nashpath, sourcedir)
 }
 
 func TestFailsOnUnreadableFileInsideSourcePath(t *testing.T) {
-		nashpath, rmnashpath := fixture.Tmpdir(t)
-		defer rmnashpath()
-		
-		sourcedir, rmsourcedir := fixture.Tmpdir(t)
-		defer rmsourcedir()
-		
-		readableFile := filepath.Join(sourcedir, "file1.sh")
-		unreadableFile := filepath.Join(sourcedir, "file2.sh")
-		
-		fixture.CreateFiles(t, []string{readableFile, unreadableFile})
-		fixture.Chmod(t, unreadableFile, writeOnly) 
-		
-		assertInstallLibFails(t, nashpath, sourcedir)
+	nashpath, rmnashpath := fixture.Tmpdir(t)
+	defer rmnashpath()
+
+	sourcedir, rmsourcedir := fixture.Tmpdir(t)
+	defer rmsourcedir()
+
+	readableFile := filepath.Join(sourcedir, "file1.sh")
+	unreadableFile := filepath.Join(sourcedir, "file2.sh")
+
+	fixture.CreateFiles(t, []string{readableFile, unreadableFile})
+	fixture.Chmod(t, unreadableFile, writeOnly)
+
+	assertInstallLibFails(t, nashpath, sourcedir)
 }
 
 func TestFailsOnUnwriteableNashPath(t *testing.T) {
-		nashpath, rmnashpath := fixture.Tmpdir(t)
-		defer rmnashpath()
-		
-		sourcedir, rmsourcedir := fixture.Tmpdir(t)
-		defer rmsourcedir()
-		
-		fixture.Chmod(t, nashpath, readOnly)
-		fixture.CreateFile(t, filepath.Join(sourcedir, "file.sh"))
-		
-		assertInstallLibFails(t, nashpath, sourcedir)
+	nashpath, rmnashpath := fixture.Tmpdir(t)
+	defer rmnashpath()
+
+	sourcedir, rmsourcedir := fixture.Tmpdir(t)
+	defer rmsourcedir()
+
+	fixture.Chmod(t, nashpath, readOnly)
+	fixture.CreateFile(t, filepath.Join(sourcedir, "file.sh"))
+
+	assertInstallLibFails(t, nashpath, sourcedir)
 }
 
 func TestFailsOnUnwriteableFileInsideNashLibdir(t *testing.T) {
-		nashpath, rmnashpath := fixture.Tmpdir(t)
-		defer rmnashpath()
-		
-		sourcedir, rmsourcedir := fixture.Tmpdir(t)
-		defer rmsourcedir()
-		
-		filename := "test.sh"
-		sourcefile := filepath.Join(sourcedir, filename)
-		expectedInstalledFile := filepath.Join(
-			main.NashLibDir(nashpath),
-			filepath.Base(sourcedir),
-			filename,
-		)
-		
-		fixture.CreateFiles(t, []string{sourcefile, expectedInstalledFile})
-		fixture.Chmod(t, expectedInstalledFile, readOnly)
-		
-		assertInstallLibFails(t, nashpath, sourcedir)
+	nashpath, rmnashpath := fixture.Tmpdir(t)
+	defer rmnashpath()
+
+	sourcedir, rmsourcedir := fixture.Tmpdir(t)
+	defer rmsourcedir()
+
+	filename := "test.sh"
+	sourcefile := filepath.Join(sourcedir, filename)
+	expectedInstalledFile := filepath.Join(
+		main.NashLibDir(nashpath),
+		filepath.Base(sourcedir),
+		filename,
+	)
+
+	fixture.CreateFiles(t, []string{sourcefile, expectedInstalledFile})
+	fixture.Chmod(t, expectedInstalledFile, readOnly)
+
+	assertInstallLibFails(t, nashpath, sourcedir)
 }
 
 func assertInstallLibFails(t *testing.T, nashpath string, sourcepath string) {
-		t.Helper()
-		
-		err := main.InstallLib(nashpath, sourcepath)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
+	t.Helper()
+
+	err := main.InstallLib(nashpath, sourcepath)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
 }
 
 const writeOnly = 0333

--- a/internal/sh/shell_import_test.go
+++ b/internal/sh/shell_import_test.go
@@ -3,6 +3,7 @@ package sh_test
 import (
 	"bytes"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/NeowayLabs/nash/internal/sh"
@@ -103,7 +104,6 @@ func TestImportsLibFromWorkingDirBeforeLibAndStdlib(t *testing.T) {
 }
 
 func TestStdErrOnInvalidSearchPaths(t *testing.T) {
-
 	type testCase struct {
 		name     string
 		nashpath string
@@ -179,10 +179,16 @@ func TestStdErrOnInvalidSearchPaths(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			// TODO: find better way to test non fatal import errors
-			_, err := sh.NewShell(c.nashpath, c.nashroot)
-			if err != nil {
-				t.Fatalf("unexpected error[%s]", err)
+			_, err := sh.NewAbortShell(c.nashpath, c.nashroot)
+			if c.errmsg != "" {
+				if err == nil {
+					t.Fatalf("expected err[%s]", c.errmsg)
+				}
+				if !strings.HasPrefix(err.Error(), c.errmsg) {
+					t.Fatalf("errors mismatch: [%s] didnt contains [%s]", err, c.errmsg)
+				}
+			} else if err != nil {
+				t.Fatalf("got unexpected error[%s]", err)
 			}
 		})
 	}

--- a/internal/sh/util_test.go
+++ b/internal/sh/util_test.go
@@ -13,7 +13,6 @@ func TestBuildEnv(t *testing.T) {
 	}
 
 	penv := buildenv(env)
-
 	if len(penv) != 0 {
 		t.Errorf("Invalid env length")
 		return
@@ -81,4 +80,3 @@ func TestBuildEnv(t *testing.T) {
 		return
 	}
 }
-

--- a/internal/testing/fixture/io.go
+++ b/internal/testing/fixture/io.go
@@ -1,12 +1,12 @@
 package fixture
 
 import (
-	"testing"
+	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"math/rand"
 	"os"
-	"fmt"
+	"path/filepath"
+	"testing"
 )
 
 // Tmpdir creates a temporary dir and returns a function that can be used
@@ -14,12 +14,17 @@ import (
 // call on the given testing.T.
 func Tmpdir(t *testing.T) (string, func()) {
 	t.Helper()
-	
+
 	dir, err := ioutil.TempDir("", "nash-tests")
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	return dir, func() {
 		err := os.RemoveAll(dir)
 		if err != nil {
@@ -32,7 +37,7 @@ func Tmpdir(t *testing.T) (string, func()) {
 // the given testing.T if something goes wrong.
 func MkdirAll(t *testing.T, nashlib string) {
 	t.Helper()
-	
+
 	err := os.MkdirAll(nashlib, os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
@@ -47,14 +52,14 @@ func MkdirAll(t *testing.T, nashlib string) {
 // the filepath to its contents
 func CreateFiles(t *testing.T, filepaths []string) map[string]string {
 	t.Helper()
-	
+
 	createdFiles := map[string]string{}
-	
+
 	for _, f := range filepaths {
-		contents := CreateFile(t, f)	
+		contents := CreateFile(t, f)
 		createdFiles[f] = contents
 	}
-	
+
 	return createdFiles
 }
 
@@ -68,23 +73,23 @@ func CreateFiles(t *testing.T, filepaths []string) map[string]string {
 // Return the contents generated for the file (and that has been written on it).
 func CreateFile(t *testing.T, f string) string {
 	t.Helper()
-	
+
 	dir := filepath.Dir(f)
 	MkdirAll(t, dir)
-		
+
 	contents := fmt.Sprintf("randomContents=%d", rand.Int())
-		
+
 	err := ioutil.WriteFile(f, []byte(contents), 0644)
 	if err != nil {
 		t.Fatalf("error[%s] writing file[%s]", err, f)
 	}
-		
+
 	return contents
 }
 
 func WorkingDir(t *testing.T) string {
 	t.Helper()
-	
+
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +99,7 @@ func WorkingDir(t *testing.T) string {
 
 func ChangeDir(t *testing.T, path string) {
 	t.Helper()
-	
+
 	err := os.Chdir(path)
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +108,7 @@ func ChangeDir(t *testing.T, path string) {
 
 func Chmod(t *testing.T, path string, mode os.FileMode) {
 	t.Helper()
-	
+
 	err := os.Chmod(path, mode)
 	if err != nil {
 		t.Fatal(err)

--- a/nash.go
+++ b/nash.go
@@ -19,19 +19,33 @@ type (
 	}
 )
 
-// New creates a new `nash.Shell` instance.
-func New(nashpath string, nashroot string) (*Shell, error) {
-	interp, err := shell.NewShell(nashpath, nashroot)
+func newShell(nashpath string, nashroot string, abort bool) (*Shell, error) {
+	var (
+		nash Shell
+		err  error
+	)
 
+	if abort {
+		nash.interp, err = shell.NewAbortShell(nashpath, nashroot)
+	} else {
+		nash.interp, err = shell.NewShell(nashpath, nashroot)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	nash := Shell{
-		interp: interp,
-	}
-
 	return &nash, nil
+}
+
+// New creates a new `nash.Shell` instance.
+func New(nashpath string, nashroot string) (*Shell, error) {
+	return newShell(nashpath, nashroot, false)
+}
+
+// NewAbort creates a new shell that aborts in case of error on initialization.
+// Useful for tests, to avoid trashing the output log.
+func NewAbort(nashpath string, nashroot string) (*Shell, error) {
+	return newShell(nashpath, nashroot, true)
 }
 
 // SetDebug enable some logging for debug purposes.

--- a/nash_test.go
+++ b/nash_test.go
@@ -2,9 +2,9 @@ package nash
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"testing"
-	"io/ioutil"
 
 	"github.com/NeowayLabs/nash/sh"
 	"github.com/NeowayLabs/nash/tests"
@@ -17,7 +17,7 @@ func TestExecuteFile(t *testing.T) {
 	testfile := tests.Testdir + "/ex1.sh"
 
 	var out bytes.Buffer
-	shell, cleanup := newShell(t)
+	shell, cleanup := newTestShell(t)
 	defer cleanup()
 
 	shell.SetNashdPath(tests.Nashcmd)
@@ -38,7 +38,7 @@ func TestExecuteFile(t *testing.T) {
 }
 
 func TestExecuteString(t *testing.T) {
-	shell, cleanup := newShell(t)
+	shell, cleanup := newTestShell(t)
 	defer cleanup()
 
 	var out bytes.Buffer
@@ -76,9 +76,9 @@ func TestExecuteString(t *testing.T) {
 }
 
 func TestSetvar(t *testing.T) {
-	shell,cleanup := newShell(t)
+	shell, cleanup := newTestShell(t)
 	defer cleanup()
-	
+
 	shell.Newvar("__TEST__", sh.NewStrObj("something"))
 
 	var out bytes.Buffer
@@ -104,31 +104,31 @@ func TestSetvar(t *testing.T) {
 	}
 }
 
-func newShell(t *testing.T) (*Shell, func()) {
+func newTestShell(t *testing.T) (*Shell, func()) {
 	t.Helper()
-	
+
 	nashpath, pathclean := tmpdir(t)
 	nashroot, rootclean := tmpdir(t)
-	
-	s, err := New(nashpath, nashroot)
+
+	s, err := NewAbort(nashpath, nashroot)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	return s, func() {
 		pathclean()
 		rootclean()
 	}
 }
 
-
 func tmpdir(t *testing.T) (string, func()) {
 	t.Helper()
-	
+
 	dir, err := ioutil.TempDir("", "nash-tests")
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	return dir, func() {
 		err := os.RemoveAll(dir)
 		if err != nil {


### PR DESCRIPTION
On OSX, the directories /tmp and /var are symlinks to
/private/tmp and /private/var respectively.
This change adds an additional call to filepath.EvalSymlinks
before using paths obtained by TempDir.

Also, this change identified a problem related to logging of
the warnings when nashpath and/or nashroot aren't properly set.
As there are tests that do instantiate nash with wrong directories
for testing, this was making a mess in the stderr of the tests
because now nash doesn't abort in case of errors. This change address that too. (Maybe not in the best way)

Signed-off-by: Tiago de Bem <tiago.moura@nginx.com>